### PR TITLE
Update references to repository to point to github

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,42 +1,40 @@
 # How to contribute
-First off all, thanks for considering to contribute to Allpix<sup>2</sup>. We appreciate any type of merge request, ranging from small bugfixes, improvements to the documentation to entirely new functionality. We, the maintainers, will try to our best to look carefully at every merge request. If you only want to submit an issue, that is also very welcome, please continue directly to the [issue tracker](https://gitlab.cern.ch/simonspa/allpix-squared/issues) to open a ticket.
+First off all, thanks for considering to contribute to Allpix<sup>2</sup>. We appreciate any type of merge request, ranging from small bugfixes, improvements to the documentation to entirely new functionality. We, the maintainers, will try to our best to look carefully at every merge request. If you only want to submit an issue, that is also very welcome, please continue directly to the [issue tracker](https://github.com/allpix-squared/allpix-squared/issues) to open a ticket.
 
 The following is a set of guidelines that will help both you as submitter as well as us maintainers to make it as easy as possible to contribute changes.
 
 ## Core and modules
 Allpix<sup>2</sup> is split up in a slim core, providing base functionality as configuration, detector geometry, management of modules, messaging as well as various utilities. The actual chain of simulation is developed in independent modules. Please try to separate any merge request for improvements or changes to the core from the implementation and updates of modules. Generally any kind of separable simulation functionality should be implemented in its own module and submitted as a individual merge request. Also try to submit individual merge request for independent changes to allow us to review them separately.
 
-If you have any doubt about the best way to implement new functionality or how to split it up, please open an issue with the discussion tag on the [issue tracker](https://gitlab.cern.ch/simonspa/allpix-squared/issues). Also please feel free to open a incomplete merge request as soon with the WIP (work-in-progress) label to allow for early discussion.
+If you have any doubt about the best way to implement new functionality or how to split it up, please open an issue with the discussion tag on the [issue tracker](https://github.com/allpix-squared/allpix-squared/issues). Also please feel free to open a incomplete merge request as soon with the WIP (work-in-progress) label to allow for early discussion.
 
 ## Getting started
 Please follow the next steps to setup your system for contributing. Note that these are slightly different from the normal installation instructions in the manual.
 
-1. Make sure you have an account on [Gitlab](gitlab.cern.ch) (restricted to CERN associates).
-2. Fork the repository by clicking on 'Fork' on the main [repository](https://gitlab.cern.ch/simonspa/allpix-squared).
-3. Clone your local fork using `git clone https://gitlab.cern.ch/simonspa/allpix-squared.git` (when using HTTPS, this has to be changed accordingly for SSH or KRB5)
+1. Make sure you have an account on [GitHub](https://github.com)
+2. Fork the repository by clicking on 'Fork' on the main [repository](https://github.com/allpix-squared/allpix-squared).
+3. Clone your local fork using `git clone https://github.com/allpix-squared/allpix-squared.git` (when using HTTPS, this has to be changed accordingly for SSH or KRB5)
 4. Install the latest version of the *clang* package with the *clang-format* and *clang-tidy* programs.
 5. Follow the build instructions using CMake explained in the User's manual.
 
 ## Making changes
-Now you can start making changes and adding new functionality to the code. 
+Now you can start making changes and adding new functionality to the code.
 
 1. Run `etc/git-hooks/install-hooks.sh` from the repository top folder to install the git-hook that automatically updates the format of the code to comply with the coding style.
 2. Create a new branch from master with a description of the change using `git checkout -b my-new-branch-name`.
 3. Read the relevant sections in the User's manual before starting to make changes.
 4. Implement the new code and frequently commit using `git commit -m 'my commit message'`. Please use descriptive messages explaining what changed.
 5. Push the code to your local mirror using `git push --set-upstream origin`.
-6. Retrieve the latest changes to the upstream master every now and then. To do this add the upstream version to your remotes using `git remote add upstream https://gitlab.cern.ch/simonspa/allpix-squared.git` (or the SSH or KRB5 version if preferred). This only has to be done once, the first time after cloning the repository. Afterwards you fetch the changes using `git fetch upstream`. Then you can add the change preferably using rebase with `git rebase upstream master`. If that causes problems you can use merge with `git merge upstream master`.
+6. Retrieve the latest changes to the upstream master every now and then. To do this add the upstream version to your remotes using `git remote add upstream https://github.com/allpix-squared/allpix-squared.git` (or the SSH or KRB5 version if preferred). This only has to be done once, the first time after cloning the repository. Afterwards you fetch the changes using `git fetch upstream`. Then you can add the change preferably using rebase with `git rebase upstream master`. If that causes problems you can use merge with `git merge upstream master`.
 
 # Submitting a pull request
 As soon as there exists something in your branch, a merge request can be opened on the main repository. Do not forget that it is not a problem to open a request for incomplete implementations.
 
 1. Retrieve the latest changes from the upstream version as explained above.
 2. Optionally format the code if you did not add the git-hook from the beginning, this can be done manually by running `make format` from the build directory.
-3. Go to [merge request](https://gitlab.cern.ch/simonspa/allpix-squared/merge_requests) and click on 'New merge request'.
+3. Go to [pull request](https://github.com/allpix-squared/allpix-squared/pulls) and click on 'New pull request'.
 4. Follow the instructions. Do not forget to use the 'WIP:' prefix if your code is only partially ready. Then submit the merge request.
-5. Please wait for the maintainers to give you access to the continuous integration (CI) runners that will check your code if you do not already have it.
-6. Add all the specific runners on your local repository at https://gitlab.cern.ch/your-username/allpix-squared/settings/ci_cd.
-7. The pipeline can now be restarted and the CI will check your changes. If the CI fails and gives an error please refer to the log containing a description about what went wrong. It is very likely that errors will appear because Allpix<sup>2</sup> enforces a very strict policy of compiler errors and requires full compliance of the clang-tidy 'linter' tool, which frequently complains about minor changes. This clang-tidy tool can also be run locally on your pc by executing `make check-lint` from the build directory. Easy changes can be fixed automatically by executing `make lint`.
-8. The maintainers will look at your proposed changes and likely provide some (constructive) feedback.
-9. Please continue to update the code with the received comments until every reviewer and the continuous integration is happy :)
-10. Your merge request can now be merged in. Congratulations and thank you very much, you have contributed something new to the repository!
+5. The continuous integration (CI) will check your changes. If the CI fails and gives an error please refer to the log containing a description about what went wrong. It is very likely that errors will appear because Allpix<sup>2</sup> enforces a very strict policy of compiler errors and requires full compliance of the clang-tidy 'linter' tool, which frequently complains about minor changes. This clang-tidy tool can also be run locally on your pc by executing `make check-lint` from the build directory. Easy changes can be fixed automatically by executing `make lint`.
+6. The maintainers will look at your proposed changes and likely provide some (constructive) feedback.
+7. Please continue to update the code with the received comments until every reviewer and the continuous integration is happy :)
+8. Your merge request can now be merged in. Congratulations and thank you very much, you have contributed something new to the repository!

--- a/doc/usermanual/chapters/development.tex
+++ b/doc/usermanual/chapters/development.tex
@@ -13,10 +13,10 @@ After this, it is up to the developer to implement all the required functionalit
 \item The framework documentation in Section \ref{sec:framework} for an introduction to the different parts of the framework.
 \item The module documentation in Section \ref{sec:modules} for a description of functionality other modules already provide and to look for similar modules which can help during development.
 \item The Doxygen (core) reference documentation included in the framework \todo{available at location X}.
-\item The latest version of the source code of all the modules (and the core itself). Freely available to copy and modify under the MIT license at \url{https://gitlab.cern.ch/simonspa/allpix-squared/tree/master}.
+\item The latest version of the source code of all the modules (and the core itself). Freely available to copy and modify under the MIT license at \url{https://github.com/allpix-squared/allpix-squared/tree/master}.
 \end{itemize}
 
-Any module that may be useful for other people can be contributed back to the main repository. It is very much encouraged to send a merge-request at \url{https://gitlab.cern.ch/simonspa/allpix-squared/merge_requests}.
+Any module that may be useful for other people can be contributed back to the main repository. It is very much encouraged to send a merge-request at \url{https://github.com/allpix-squared/allpix-squared/pulls}.
 
 \subsection{Adding a New Detector Model}
 \label{sec:adding_detector_model}
@@ -25,7 +25,7 @@ Custom detector models can be easily added to the framework. Required informatio
 \item Create a new file with the internal name of the model followed by the \textit{.conf} suffix (for example \texttt{your\_model.conf}).
 \item Add a configuration parameter \texttt{type} with the type of the model, at the moment either 'monolithic' or 'hybrid' for respectively monolithic sensors or hybrid models with bump bonds.
 \item Add all the required parameters and possibly other optional parameters explained in Section \ref{sec:detector_models}.
-\item Include the detector model in the search path of the framework by adding the \texttt{model\_path} parameter to the general setting of the main configuration (see Section \ref{sec:framework_parameters}) pointing to either directly to the detector model file or the detector containing it (note that files in this path overwrite models with the same name in the default model folder). 
+\item Include the detector model in the search path of the framework by adding the \texttt{model\_path} parameter to the general setting of the main configuration (see Section \ref{sec:framework_parameters}) pointing to either directly to the detector model file or the detector containing it (note that files in this path overwrite models with the same name in the default model folder).
 \end{enumerate}
 
-Models can be contributed to the repository to make them available to other users of the framework. To add the detector model to the framework the configuration file should be moved to the \textit{models} folder of the repository. Then the file should be added to the installation target in the \textit{CMakeLists.txt} file in the \textit{models} directory. Afterwards a merge-request can be created at \url{https://gitlab.cern.ch/simonspa/allpix-squared/merge_requests}.
+Models can be contributed to the repository to make them available to other users of the framework. To add the detector model to the framework the configuration file should be moved to the \textit{models} folder of the repository. Then the file should be added to the installation target in the \textit{CMakeLists.txt} file in the \textit{models} directory. Afterwards a pull request can be created at \url{https://github.com/allpix-squared/allpix-squared/pulls}.

--- a/doc/usermanual/chapters/installation.tex
+++ b/doc/usermanual/chapters/installation.tex
@@ -16,7 +16,7 @@ For various modules additional dependencies are necessary. For details about the
 -DGEANT4_BUILD_MULTITHREADED=ON
 -DGEANT4_USE_GDML=ON
 -DGEANT4_USE_QT=ON
--DGEANT4_USE_XM=ON 
+-DGEANT4_USE_XM=ON
 -DGEANT4_USE_OPENGL_X11=ON
 -DGEANT4_USE_SYSTEM_CLHEP=OFF
 \end{verbatim}
@@ -25,10 +25,10 @@ For various modules additional dependencies are necessary. For details about the
 Extra flags needs to be set for building an \apsq installation without these dependencies. Details about these configuration options are given in Section \ref{sec:cmake_config}.
 
 \subsection{Downloading the source code}
-The latest version of \apsq can be fetched from the Gitlab repository at \url{https://gitlab.cern.ch/simonspa/allpix-squared}. This version is under heavy development, but should work out-of-the-box. The software can be cloned and accessed as follows:
+The latest version of \apsq can be fetched from the GitHub repository at \url{https://github.com/allpix-squared/allpix-squared}. This version is under heavy development, but should work out-of-the-box. The software can be cloned and accessed as follows:
 
 \begin{verbatim}
-$ git clone https://gitlab.cern.ch/simonspa/allpix-squared
+$ git clone https://github.com/allpix-squared/allpix-squared
 $ cd allpix-squared
 \end{verbatim}
 
@@ -57,8 +57,8 @@ $ cmake ..
 
 CMake can be run with several extra arguments to change the type of installation. These options can be set with -D\textit{option} (see the end of this section for an example). Currently the following options are supported:
 \begin{itemize}
-\item \textbf{CMAKE\_INSTALL\_PREFIX}: The directory to use as a prefix for installing the binaries, libraries and data. Defaults to the source directory (where the folders \textit{bin/} and \textit{lib/} are added). 
-\item \textbf{CMAKE\_BUILD\_TYPE}: Type of build to install, defaults to \texttt{RelWithDebInfo} (compiles with optimizations and debug symbols). Other possible options are \texttt{Debug} (for compiling with no optimizations, but with debug symbols and extended tracing using the Clang Address Sanitizer library) and \texttt{Release} (for compiling with full optimizations and no debug symbols). 
+\item \textbf{CMAKE\_INSTALL\_PREFIX}: The directory to use as a prefix for installing the binaries, libraries and data. Defaults to the source directory (where the folders \textit{bin/} and \textit{lib/} are added).
+\item \textbf{CMAKE\_BUILD\_TYPE}: Type of build to install, defaults to \texttt{RelWithDebInfo} (compiles with optimizations and debug symbols). Other possible options are \texttt{Debug} (for compiling with no optimizations, but with debug symbols and extended tracing using the Clang Address Sanitizer library) and \texttt{Release} (for compiling with full optimizations and no debug symbols).
 \item \textbf{MODEL\_DIRECTORY}: Directory to install the internal models to. Defaults to not installing if the \textbf{CMAKE\_INSTALL\_PREFIX} is set to the directory containing the sources (the default). Otherwise the default value is equal to the directory \textbf{CMAKE\_INSTALL\_PREFIX}\-\textit{/share/allpix/}. The install directory is automatically added to the model search path used by the geometry model parsers to find all the detector models.
 \item \textbf{BUILD\_\textit{module\_name}}: If the specific \textit{module\_name} should be installed or not. Defaults to ON, thus all modules are installed by default. This set of parameters have to be set appropriately for a build without extra dependencies as specified in \ref{sec:prerequisites}.
 \item \textbf{BUILD\_ALL\_MODULES}: Build all included modules, defaulting to OFF. This overwrites any selection using the parameters described above.

--- a/doc/usermanual/chapters/introduction.tex
+++ b/doc/usermanual/chapters/introduction.tex
@@ -1,6 +1,6 @@
 \section{Introduction}
 \label{sec:introduction}
-\apsq is a generic simulation framework for silicon tracker and vertex detectors written in modern C++. It is the successor of a previously developed simulation framework called AllPix~\cite{ap1wiki,ap1git}. The goal of the \apsq framework is to provide a complete and easy-to-use package for simulating the performance of detectors from a general source of particles until the digitization of hits in the detector chip. 
+\apsq is a generic simulation framework for silicon tracker and vertex detectors written in modern C++. It is the successor of a previously developed simulation framework called AllPix~\cite{ap1wiki,ap1git}. The goal of the \apsq framework is to provide a complete and easy-to-use package for simulating the performance of detectors from a general source of particles until the digitization of hits in the detector chip.
 
 The framework builds upon other packages to perform tasks in the simulation chain, most notably Geant4~\cite{geant4} for the deposition of charge carriers in the sensor and ROOT~\cite{root} for producing histograms and saving the produced data to storage. The core of the framework focuses on the simulation of charge transport in semiconductor detectors and the digitization to hits in the frontend electronics. The framework does not perform a reconstruction of the particle tracks.
 
@@ -29,12 +29,12 @@ The framework builds upon other packages to perform tasks in the simulation chai
 \subsection{History}
 Development of AllPix (the original version) started around 2012 as a generic simulation framework for pixel detectors. It has been succesfully used for simulating a variety of different detector setups through the years. Originally written as a Geant4 user application the framework has grown `organically` after new features continued to be added. Around 2016 discussions between collaborators started to discuss a rewrite of the software from scratch. Primary possibilities for improvements included better modularity, more extensive configuration options and an easier geometry setup.
 
-Early development of \apsq started in end of 2016, but most of the initial rework in modern C++ has been carried out in the framework of a technical student project in the beginning of 2017. The core of the framework starts to mature and initial versions of various generic core modules have been created at the time of writing. 
+Early development of \apsq started in end of 2016, but most of the initial rework in modern C++ has been carried out in the framework of a technical student project in the beginning of 2017. The core of the framework starts to mature and initial versions of various generic core modules have been created at the time of writing.
 
 \subsection{Scope of this manual}
 This document is the primary User's Guide for \apsq. It presents all the necessary requirements to start using the framework. In more detail this manual is designed to:
 \begin{itemize}
-\item guide all new users through the installation 
+\item guide all new users through the installation
 \item introduce new users to the toolkit for the purpose of running their own simulations
 \item explain the structure of the core framework and the components it provides to the modules
 \item provide detailed information about all modules and how-to use and configure them
@@ -44,4 +44,4 @@ This document is the primary User's Guide for \apsq. It presents all the necessa
 In the manual an overview of the framework is given, more detailed information on the code itself can be found in the Doxygen reference manual. The reader does not need any programming experience to get started, but knowledge of (modern) C++ will be useful in the later chapters.
 
 \subsection{Support and reporting issues}
-We are happy to receive feedback on any problem that might arise. Reports for issues, questions about unclear parts, as well as suggestions for improvements, are very much appreciated. These should preferably be brought up on the issues page of the repository, which can be found at \url{https://gitlab.cern.ch/simonspa/allpix-squared/issues}.
+We are happy to receive feedback on any problem that might arise. Reports for issues, questions about unclear parts, as well as suggestions for improvements, are very much appreciated. These should preferably be brought up on the issues page of the repository, which can be found at \url{https://github.com/allpix-squared/allpix-squared/issues}.

--- a/doc/usermanual/chapters/quick_start.tex
+++ b/doc/usermanual/chapters/quick_start.tex
@@ -1,11 +1,11 @@
 \section{Quick Start}
-This chapter serves as a swift introduction to \apsq for users who prefer to start quickly and learn the details while simulating. The typical user should skip the next paragraphs and continue to Section \ref{sec:introduction} instead. 
+This chapter serves as a swift introduction to \apsq for users who prefer to start quickly and learn the details while simulating. The typical user should skip the next paragraphs and continue to Section \ref{sec:introduction} instead.
 
 \apsq is a generic simulation framework for pixel detectors. It provides a modular, flexible and user-friendly structure for the simulation of independent detectors in the geometry. The framework currently relies on the Geant4~\cite{geant4}, ROOT~\cite{root} and Eigen3~\cite{eigen3} libraries, that need to be installed and loaded before using \apsq.
 
 The minimal, default installation can be installed by executing the commands below. More detailed installation instructions are found in Section \ref{sec:installation}.
 \begin{verbatim}
-$ git clone https://gitlab.cern.ch/simonspa/allpix-squared
+$ git clone https://github.com/allpix-squared/allpix-squared
 $ cd allpix-squared
 $ mkdir build && cd build/
 $ cmake ..


### PR DESCRIPTION
Since we are about ot move our main repository to GitHub, I updated all references in the documentation to point to the newly created repo in the allpix-squared organization.

To do:
* [ ] Update build batch once we have the Travis CI running
* [ ] Potentially leave the CERN Gitlab CI badge in, since we might mirror for CI purposes?
* [ ] Update the coverity badge to point to the main repo instead of @Koensw personal copy