### PR TITLE
Add log message when successfully applying options from cmdline

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Allpix<sup>2</sup> has been developed and is maintained by
 * Simon Spannagel, CERN, @simonspa
 
 The following authors, in alphabetical order, have contributed to Allpix<sup>2</sup>:
+* Mohamed Moanis Ali, Free University of Bozen-Bolzano, @mmoanis
 * Mathieu Benoit, Université de Genève, @mbenoit
 * Thomas Billoud, Université de Montréal, @tbilloud
 * Tobias Bisanz, Georg-August-Universität Göttingen, @tbisanz

--- a/src/core/config/OptionParser.cpp
+++ b/src/core/config/OptionParser.cpp
@@ -10,6 +10,7 @@
 #include "OptionParser.hpp"
 
 #include "ConfigReader.hpp"
+#include "core/utils/log.h"
 
 using namespace allpix;
 
@@ -39,6 +40,7 @@ void OptionParser::parseOption(std::string line) {
 
 bool OptionParser::applyGlobalOptions(Configuration& config) {
     for(auto& key_value : global_options_) {
+        LOG(INFO) << "Set " << key_value.first << '=' << key_value.second;
         config.setText(key_value.first, key_value.second);
     }
     return !global_options_.empty();
@@ -50,6 +52,7 @@ bool OptionParser::applyOptions(const std::string& identifier, Configuration& co
     }
 
     for(auto& key_value : identifier_options_[identifier]) {
+        LOG(INFO) << "Set " << key_value.first << '=' << key_value.second << " for " << identifier;
         config.setText(key_value.first, key_value.second);
     }
     return true;

--- a/src/core/config/OptionParser.cpp
+++ b/src/core/config/OptionParser.cpp
@@ -40,7 +40,7 @@ void OptionParser::parseOption(std::string line) {
 
 bool OptionParser::applyGlobalOptions(Configuration& config) {
     for(auto& key_value : global_options_) {
-        LOG(INFO) << "Set " << key_value.first << '=' << key_value.second;
+        LOG(INFO) << "Setting provided option " << key_value.first << '=' << key_value.second;
         config.setText(key_value.first, key_value.second);
     }
     return !global_options_.empty();
@@ -52,7 +52,7 @@ bool OptionParser::applyOptions(const std::string& identifier, Configuration& co
     }
 
     for(auto& key_value : identifier_options_[identifier]) {
-        LOG(INFO) << "Set " << key_value.first << '=' << key_value.second << " for " << identifier;
+        LOG(INFO) << "Setting provided option " << key_value.first << '=' << key_value.second << " for " << identifier;
         config.setText(key_value.first, key_value.second);
     }
     return true;


### PR DESCRIPTION
When a user uses the command line options `-g` or `-o` to specify some parameter for a module or a detector, there is no indication about whether this option was set correctly or not which may cause confusion. For example, a user might make a typo in a parameter name and expects that the parameter was set correctly while it wasn't.

IMHO, adding an INFO level log message when the user's specified parameters on the command line are successfully set would help to make it clear about the configuration used during the simulation.