### PR TITLE
Update Messenger to allow modules to register to multiple message types

### DIFF
--- a/src/core/messenger/Messenger.cpp
+++ b/src/core/messenger/Messenger.cpp
@@ -165,7 +165,7 @@ bool Messenger::dispatch_message(Module* source,
     // Send messages only to their specific listeners
     for(auto& delegate : delegates_[type_idx][id]) {
         if(check_send(message.get(), delegate.get())) {
-            LOG(TRACE) << "Sending message " << allpix::demangle(type_idx.name()) << " " << name << " " << id << " from " << source->getUniqueName()
+            LOG(TRACE) << "Sending message " << allpix::demangle(type_idx.name()) << " from " << source->getUniqueName()
                        << " to " << delegate->getUniqueName();
             // Construct BaseMessage where message should be stored
             auto& dest = messages_[delegate->getUniqueName()][type_idx];

--- a/src/core/messenger/Messenger.cpp
+++ b/src/core/messenger/Messenger.cpp
@@ -162,17 +162,13 @@ bool Messenger::dispatch_message(Module* source,
     const BaseMessage* inst = message.get();
     std::type_index type_idx = typeid(*inst);
 
-    LOG(STATUS) << "SENDING MSG " << source->getUniqueName() << " " << name << " " << id << " " << allpix::demangle(type_idx.name());
-
     // Send messages only to their specific listeners
     for(auto& delegate : delegates_[type_idx][id]) {
         if(check_send(message.get(), delegate.get())) {
-            LOG(STATUS) << "Sending message " << allpix::demangle(type_idx.name()) << " " << name << " " << id << " from " << source->getUniqueName()
+            LOG(TRACE) << "Sending message " << allpix::demangle(type_idx.name()) << " " << name << " " << id << " from " << source->getUniqueName()
                        << " to " << delegate->getUniqueName();
             // Construct BaseMessage where message should be stored
             auto& dest = messages_[delegate->getUniqueName()][type_idx];
-
-            LOG(STATUS) << "SENT MSG " << delegate->getUniqueName() << ' ' << allpix::demangle(type_idx.name());
 
             delegate->process(message, name, dest);
             send = true;

--- a/src/core/messenger/Messenger.hpp
+++ b/src/core/messenger/Messenger.hpp
@@ -131,12 +131,6 @@ namespace allpix {
          */
         bool hasReceiver(Module* source, const std::shared_ptr<BaseMessage>& message);
 
-        /**
-         * @brief Check if a module is satisfied for running (all required messages received)
-         * @return True if satisfied, false otherwise
-         */
-        bool isSatisfied(Module* module) const;
-
     private:
         /**
          * @brief Add a delegate to the listeners
@@ -167,8 +161,7 @@ namespace allpix {
         static DelegateMap delegates_;
         static DelegateIteratorMap delegate_to_iterator_;
 
-        std::map<std::string, DelegateTypes> messages_;
-        std::map<std::string, bool> satisfied_modules_;
+        std::map<std::string, std::map<std::type_index, DelegateTypes>> messages_;
         std::vector<std::shared_ptr<BaseMessage>> sent_messages_;
 
         mutable std::mutex mutex_;

--- a/src/core/messenger/Messenger.tpp
+++ b/src/core/messenger/Messenger.tpp
@@ -45,7 +45,9 @@ namespace allpix {
 
     template <typename T> std::shared_ptr<T> Messenger::fetchMessage(Module* module) {
         static_assert(std::is_base_of<BaseMessage, T>::value, "Fetched message should inherit from Message class");
-        return std::static_pointer_cast<T>(messages_.at(module->getUniqueName()).single);
+        std::type_index type_idx = typeid(T);
+        LOG(STATUS) << "Fetching MSG " << module->getUniqueName() << ' ' << allpix::demangle(type_idx.name());
+        return std::static_pointer_cast<T>(messages_.at(module->getUniqueName()).at(type_idx).single);
     }
 
     template <typename T> std::vector<std::shared_ptr<T>> Messenger::fetchMultiMessage(Module* module) {
@@ -53,8 +55,10 @@ namespace allpix {
 
         // TODO: do nothing if T == BaseMessage; there is no need to cast (optimized out)?
 
+        std::type_index type_idx = typeid(T);
+
         // Construct an empty vector in case no previous modules created one during dispatch
-        auto base_messages = messages_[module->getUniqueName()].multi;
+        auto base_messages = messages_.at(module->getUniqueName()).at(type_idx).multi;
 
         std::vector<std::shared_ptr<T>> derived_messages;
         for(auto& message : base_messages) {

--- a/src/core/messenger/Messenger.tpp
+++ b/src/core/messenger/Messenger.tpp
@@ -46,7 +46,6 @@ namespace allpix {
     template <typename T> std::shared_ptr<T> Messenger::fetchMessage(Module* module) {
         static_assert(std::is_base_of<BaseMessage, T>::value, "Fetched message should inherit from Message class");
         std::type_index type_idx = typeid(T);
-        LOG(STATUS) << "Fetching MSG " << module->getUniqueName() << ' ' << allpix::demangle(type_idx.name());
         return std::static_pointer_cast<T>(messages_.at(module->getUniqueName()).at(type_idx).single);
     }
 

--- a/src/core/module/Event.cpp
+++ b/src/core/module/Event.cpp
@@ -127,7 +127,7 @@ void Event::run(std::shared_ptr<Module>& module) {
 
     // Check if the module is satisfied to run
     if(!module->isSatisfied(this)) {
-        LOG(STATUS) << "Not all required messages are received for " << module->get_identifier().getUniqueName()
+        LOG(TRACE) << "Not all required messages are received for " << module->get_identifier().getUniqueName()
                    << ", skipping module!";
         return;
     }

--- a/src/core/module/Event.hpp
+++ b/src/core/module/Event.hpp
@@ -162,15 +162,6 @@ namespace allpix {
          */
         void handle_iomodule(const std::shared_ptr<Module>& module);
 
-        /**
-         * @brief Changes the current context of the event to that of the given module
-         * @param module The new context to change to
-         * @warning This function should be called before calling the same module's \ref Module::run() "run function"
-         *
-         * Simplifies message handling.
-         */
-        Event* with_context(const std::shared_ptr<Module>& module);
-
         // List of modules that constitutes this event
         ModuleList modules_;
 

--- a/src/core/module/Module.cpp
+++ b/src/core/module/Module.cpp
@@ -164,8 +164,3 @@ ModuleIdentifier Module::get_identifier() const {
 void Module::add_delegate(Messenger* messenger, BaseDelegate* delegate) {
     delegates_.emplace_back(messenger, delegate);
 }
-bool Module::check_delegates() {
-    // Return false if any delegate is not satisfied
-    return std::all_of(
-        delegates_.cbegin(), delegates_.cend(), [](auto& delegate) { return delegate.second->isSatisfied(); });
-}

--- a/src/core/module/Module.hpp
+++ b/src/core/module/Module.hpp
@@ -142,6 +142,12 @@ namespace allpix {
          */
         virtual void finalize() {}
 
+        /**
+         * @brief Checks if the module is ready to run in the given event
+         * @param Event pointer to the event the module will run
+         */
+        virtual bool isSatisfied(Event* event) const { (void)event; return true; }
+
     protected:
         /**
          * @brief Get the module configuration for internal use
@@ -185,10 +191,7 @@ namespace allpix {
          * @param delegate Delegate object
          */
         void add_delegate(Messenger* messenger, BaseDelegate* delegate);
-        /**
-         * @brief Check if all delegates are satisfied
-         */
-        bool check_delegates();
+
         std::vector<std::pair<Messenger*, BaseDelegate*>> delegates_;
 
         std::shared_ptr<Detector> detector_;

--- a/src/modules/CapacitiveTransfer/CapacitiveTransferModule.cpp
+++ b/src/modules/CapacitiveTransfer/CapacitiveTransferModule.cpp
@@ -38,7 +38,7 @@ CapacitiveTransferModule::CapacitiveTransferModule(Configuration& config,
     config_.setDefault("minimum_gap", config_.get<double>("nominal_gap"));
 
     // Require propagated deposits for single detector
-    messenger->bindSingle<CapacitiveTransferModule, PropagatedChargeMessage, MsgFlags::REQUIRED>(this);
+    messenger->bindSingle<CapacitiveTransferModule, PropagatedChargeMessage>(this);
 }
 
 void CapacitiveTransferModule::init(std::mt19937_64&) {
@@ -391,4 +391,15 @@ void CapacitiveTransferModule::finalize() {
             coupling_map->Write();
         }
     }
+}
+
+// check if the required messages are present in the event
+bool CapacitiveTransferModule::isSatisfied(Event* event) const {
+    try {
+        auto propagated_message = event->fetchMessage<PropagatedChargeMessage>();
+    } catch (std::out_of_range&) {
+        return false;
+    }
+
+    return true;
 }

--- a/src/modules/CapacitiveTransfer/CapacitiveTransferModule.hpp
+++ b/src/modules/CapacitiveTransfer/CapacitiveTransferModule.hpp
@@ -69,7 +69,7 @@ namespace allpix {
          * @brief Checks if the module is ready to run in the given event
          * @param Event pointer to the event the module will run
          */
-        virtual bool isSatisfied(Event* event) const;
+        virtual bool isSatisfied(Event* event) const override;
 
     private:
         // Configuration config_;

--- a/src/modules/CapacitiveTransfer/CapacitiveTransferModule.hpp
+++ b/src/modules/CapacitiveTransfer/CapacitiveTransferModule.hpp
@@ -65,6 +65,12 @@ namespace allpix {
          */
         void finalize() override;
 
+        /**
+         * @brief Checks if the module is ready to run in the given event
+         * @param Event pointer to the event the module will run
+         */
+        virtual bool isSatisfied(Event* event) const;
+
     private:
         // Configuration config_;
         Messenger* messenger_;

--- a/src/modules/CorryvreckanWriter/CorryvreckanWriterModule.cpp
+++ b/src/modules/CorryvreckanWriter/CorryvreckanWriterModule.cpp
@@ -24,7 +24,7 @@ CorryvreckanWriterModule::CorryvreckanWriterModule(Configuration& config, Messen
     : WriterModule(config), messenger_(messenger), geometryManager_(geoManager) {
 
     // Require PixelCharge messages for single detector
-    messenger_->bindMulti<CorryvreckanWriterModule, PixelHitMessage, MsgFlags::REQUIRED>(this);
+    messenger_->bindMulti<CorryvreckanWriterModule, PixelHitMessage>(this);
 
     config_.setDefault("file_name", "corryvreckanOutput.root");
     config_.setDefault("geometry_file", "corryvreckanGeometry.conf");
@@ -224,4 +224,15 @@ void CorryvreckanWriterModule::finalize() {
             geometry_file << std::endl;
         }
     }
+}
+
+// check if the required messages are present in the event
+bool CorryvreckanWriterModule::isSatisfied(Event* event) const {
+    try {
+        auto pixel_messages = event->fetchMultiMessage<PixelHitMessage>();
+    } catch (std::out_of_range&) {
+        return false;
+    }
+
+    return true;
 }

--- a/src/modules/CorryvreckanWriter/CorryvreckanWriterModule.hpp
+++ b/src/modules/CorryvreckanWriter/CorryvreckanWriterModule.hpp
@@ -58,6 +58,12 @@ namespace allpix {
          */
         void finalize() override;
 
+        /**
+         * @brief Checks if the module is ready to run in the given event
+         * @param Event pointer to the event the module will run
+         */
+        virtual bool isSatisfied(Event* event) const;
+
     private:
         // General module members
         Messenger* messenger_;

--- a/src/modules/CorryvreckanWriter/CorryvreckanWriterModule.hpp
+++ b/src/modules/CorryvreckanWriter/CorryvreckanWriterModule.hpp
@@ -62,7 +62,7 @@ namespace allpix {
          * @brief Checks if the module is ready to run in the given event
          * @param Event pointer to the event the module will run
          */
-        virtual bool isSatisfied(Event* event) const;
+        virtual bool isSatisfied(Event* event) const override;
 
     private:
         // General module members

--- a/src/modules/DefaultDigitizer/DefaultDigitizerModule.cpp
+++ b/src/modules/DefaultDigitizer/DefaultDigitizerModule.cpp
@@ -25,7 +25,7 @@ DefaultDigitizerModule::DefaultDigitizerModule(Configuration& config,
                                                std::shared_ptr<Detector> detector)
     : Module(config, std::move(detector)), messenger_(messenger) {
     // Require PixelCharge message for single detector
-    messenger_->bindSingle<DefaultDigitizerModule, PixelChargeMessage, MsgFlags::REQUIRED>(this);
+    messenger_->bindSingle<DefaultDigitizerModule, PixelChargeMessage>(this);
 
     // Set defaults for config variables
     config_.setDefault<int>("electronics_noise", Units::get(110, "e"));
@@ -218,3 +218,15 @@ void DefaultDigitizerModule::finalize() {
 
     LOG(INFO) << "Digitized " << total_hits_ << " pixel hits in total";
 }
+
+// check if the required messages are present in the event
+bool DefaultDigitizerModule::isSatisfied(Event* event) const {
+    try {
+        auto pixel_message = event->fetchMessage<PixelChargeMessage>();
+    } catch (std::out_of_range&) {
+        return false;
+    }
+
+    return true;
+}
+

--- a/src/modules/DefaultDigitizer/DefaultDigitizerModule.hpp
+++ b/src/modules/DefaultDigitizer/DefaultDigitizerModule.hpp
@@ -63,7 +63,7 @@ namespace allpix {
          * @brief Checks if the module is ready to run in the given event
          * @param Event pointer to the event the module will run
          */
-        virtual bool isSatisfied(Event* event) const;
+        virtual bool isSatisfied(Event* event) const override;
 
     private:
         Messenger* messenger_;

--- a/src/modules/DefaultDigitizer/DefaultDigitizerModule.hpp
+++ b/src/modules/DefaultDigitizer/DefaultDigitizerModule.hpp
@@ -59,6 +59,12 @@ namespace allpix {
          */
         void finalize() override;
 
+        /**
+         * @brief Checks if the module is ready to run in the given event
+         * @param Event pointer to the event the module will run
+         */
+        virtual bool isSatisfied(Event* event) const;
+
     private:
         Messenger* messenger_;
 

--- a/src/modules/DetectorHistogrammer/DetectorHistogrammerModule.cpp
+++ b/src/modules/DetectorHistogrammer/DetectorHistogrammerModule.cpp
@@ -28,7 +28,7 @@ DetectorHistogrammerModule::DetectorHistogrammerModule(Configuration& config,
     : WriterModule(config, detector), detector_(std::move(detector)) {
     // Bind messages
     messenger->bindSingle<DetectorHistogrammerModule, PixelHitMessage>(this);
-    messenger->bindSingle<DetectorHistogrammerModule, MCParticleMessage, MsgFlags::REQUIRED>(this);
+    messenger->bindSingle<DetectorHistogrammerModule, MCParticleMessage>(this);
 
     auto model = detector_->getModel();
     matching_cut_ = config.get<ROOT::Math::XYVector>("matching_cut", model->getPixelSize() * 3);
@@ -574,3 +574,17 @@ DetectorHistogrammerModule::getPrimaryParticles(std::shared_ptr<MCParticleMessag
 
     return primaries;
 }
+
+// check if the required messages are present in the event
+bool DetectorHistogrammerModule::isSatisfied(Event* event) const {
+    try {
+        auto pixels_message = event->fetchMessage<PixelHitMessage>();
+        auto mcparticle_message = event->fetchMessage<MCParticleMessage>();
+    } catch (std::out_of_range&) {
+        return false;
+    }
+
+    return true;
+}
+
+

--- a/src/modules/DetectorHistogrammer/DetectorHistogrammerModule.hpp
+++ b/src/modules/DetectorHistogrammer/DetectorHistogrammerModule.hpp
@@ -65,7 +65,7 @@ namespace allpix {
          * @brief Checks if the module is ready to run in the given event
          * @param Event pointer to the event the module will run
          */
-        virtual bool isSatisfied(Event* event) const;
+        virtual bool isSatisfied(Event* event) const override;
 
     private:
         /**

--- a/src/modules/DetectorHistogrammer/DetectorHistogrammerModule.hpp
+++ b/src/modules/DetectorHistogrammer/DetectorHistogrammerModule.hpp
@@ -61,6 +61,12 @@ namespace allpix {
          */
         void finalize() override;
 
+        /**
+         * @brief Checks if the module is ready to run in the given event
+         * @param Event pointer to the event the module will run
+         */
+        virtual bool isSatisfied(Event* event) const;
+
     private:
         /**
          * @brief Perform a sparse clustering on the PixelHits

--- a/src/modules/Dummy/DummyModule.cpp
+++ b/src/modules/Dummy/DummyModule.cpp
@@ -17,11 +17,11 @@
 using namespace allpix;
 
 DummyModule::DummyModule(Configuration& config, Messenger* messenger, GeometryManager* geo_manager)
-    : Module(config), geo_manager_(geo_manager), messenger_(messenger) {
+    : Module(config), geo_manager_(geo_manager) {
 
     // ... Implement ... (Typically bounds the required messages and optionally sets configuration defaults)
     // Input required by this module
-    messenger_->bindMulti<DummyModule, PixelHitMessage, MsgFlags::REQUIRED>(this);
+    messenger->bindMulti<DummyModule, PixelHitMessage>(this);
 }
 
 void DummyModule::init(std::mt19937_64&) {
@@ -42,4 +42,15 @@ void DummyModule::run(Event* event) const {
         std::string detectorName = message->getDetector()->getName();
         LOG(DEBUG) << "Picked up " << message->getData().size() << " objects from detector " << detectorName;
     }
+}
+
+// check if the required messages are present in the event
+bool DummyModule::isSatisfied(Event* event) const {
+    try {
+        auto messages = event->fetchMultiMessage<PixelHitMessage>();
+    } catch (std::out_of_range&) {
+        return false;
+    }
+
+    return true;
 }

--- a/src/modules/Dummy/DummyModule.hpp
+++ b/src/modules/Dummy/DummyModule.hpp
@@ -48,9 +48,14 @@ namespace allpix {
          */
         void run(Event* event) const override;
 
+        /**
+         * @brief Checks if the module is ready to run in the given event
+         * @param Event pointer to the event the module will run
+         */
+        virtual bool isSatisfied(Event* event) const;
+
     private:
         // General module members
         GeometryManager* geo_manager_;
-        Messenger* messenger_;
     };
 } // namespace allpix

--- a/src/modules/Dummy/DummyModule.hpp
+++ b/src/modules/Dummy/DummyModule.hpp
@@ -52,7 +52,7 @@ namespace allpix {
          * @brief Checks if the module is ready to run in the given event
          * @param Event pointer to the event the module will run
          */
-        virtual bool isSatisfied(Event* event) const;
+        virtual bool isSatisfied(Event* event) const override;
 
     private:
         // General module members

--- a/src/modules/GenericPropagation/GenericPropagationModule.cpp
+++ b/src/modules/GenericPropagation/GenericPropagationModule.cpp
@@ -57,7 +57,7 @@ GenericPropagationModule::GenericPropagationModule(Configuration& config,
     model_ = detector_->getModel();
 
     // Require deposits message for single detector
-    messenger_->bindSingle<GenericPropagationModule, DepositedChargeMessage, MsgFlags::REQUIRED>(this);
+    messenger_->bindSingle<GenericPropagationModule, DepositedChargeMessage>(this);
 
     // Set default value for config variables
     config_.setDefault<double>("spatial_precision", Units::get(0.25, "nm"));
@@ -819,4 +819,15 @@ void GenericPropagationModule::finalize() {
     long double average_time = total_time_ / std::max(1u, total_propagated_charges_);
     LOG(INFO) << "Propagated total of " << total_propagated_charges_ << " charges in " << total_steps_
               << " steps in average time of " << Units::display(average_time, "ns");
+}
+
+// check if the required messages are present in the event
+bool GenericPropagationModule::isSatisfied(Event* event) const {
+    try {
+        auto deposits_message = event->fetchMessage<DepositedChargeMessage>();
+    } catch (std::out_of_range&) {
+        return false;
+    }
+
+    return true;
 }

--- a/src/modules/GenericPropagation/GenericPropagationModule.hpp
+++ b/src/modules/GenericPropagation/GenericPropagationModule.hpp
@@ -67,7 +67,7 @@ namespace allpix {
          * @brief Checks if the module is ready to run in the given event
          * @param Event pointer to the event the module will run
          */
-        virtual bool isSatisfied(Event* event) const;
+        virtual bool isSatisfied(Event* event) const override;
 
     private:
         Messenger* messenger_;

--- a/src/modules/GenericPropagation/GenericPropagationModule.hpp
+++ b/src/modules/GenericPropagation/GenericPropagationModule.hpp
@@ -63,6 +63,12 @@ namespace allpix {
          */
         void finalize() override;
 
+        /**
+         * @brief Checks if the module is ready to run in the given event
+         * @param Event pointer to the event the module will run
+         */
+        virtual bool isSatisfied(Event* event) const;
+
     private:
         Messenger* messenger_;
         std::shared_ptr<const Detector> detector_;

--- a/src/modules/LCIOWriter/LCIOWriterModule.cpp
+++ b/src/modules/LCIOWriter/LCIOWriterModule.cpp
@@ -94,8 +94,8 @@ LCIOWriterModule::LCIOWriterModule(Configuration& config, Messenger* messenger, 
     : WriterModule(config), geo_mgr_(geo) {
 
     // Bind pixel hits message
-    messenger->bindMulti<LCIOWriterModule, PixelHitMessage, MsgFlags::REQUIRED>(this);
-    messenger->bindSingle<LCIOWriterModule, MCTrackMessage, MsgFlags::REQUIRED>(this);
+    messenger->bindMulti<LCIOWriterModule, PixelHitMessage>(this);
+    messenger->bindSingle<LCIOWriterModule, MCTrackMessage>(this);
 
     // Set configuration defaults:
     config_.setDefault("file_name", "output.slcio");
@@ -548,3 +548,15 @@ void LCIOWriterModule::finalize() {
         LOG(STATUS) << "Wrote GEAR geometry to file:" << std::endl << geometry_file_name_;
     }
 }
+
+// check if the required messages are present in the event
+bool LCIOWriterModule::isSatisfied(Event* event) const {
+    try {
+        auto pixel_messages = event->fetchMultiMessage<PixelHitMessage>();
+    } catch (std::out_of_range&) {
+        return false;
+    }
+
+    return true;
+}
+

--- a/src/modules/LCIOWriter/LCIOWriterModule.hpp
+++ b/src/modules/LCIOWriter/LCIOWriterModule.hpp
@@ -58,7 +58,7 @@ namespace allpix {
          * @brief Checks if the module is ready to run in the given event
          * @param Event pointer to the event the module will run
          */
-        virtual bool isSatisfied(Event* event) const;
+        virtual bool isSatisfied(Event* event) const override;
 
     private:
         GeometryManager* geo_mgr_{};

--- a/src/modules/LCIOWriter/LCIOWriterModule.hpp
+++ b/src/modules/LCIOWriter/LCIOWriterModule.hpp
@@ -54,6 +54,12 @@ namespace allpix {
          */
         void finalize() override;
 
+        /**
+         * @brief Checks if the module is ready to run in the given event
+         * @param Event pointer to the event the module will run
+         */
+        virtual bool isSatisfied(Event* event) const;
+
     private:
         GeometryManager* geo_mgr_{};
         mutable std::shared_ptr<IO::LCWriter> lcWriter_{};

--- a/src/modules/ProjectionPropagation/ProjectionPropagationModule.cpp
+++ b/src/modules/ProjectionPropagation/ProjectionPropagationModule.cpp
@@ -26,7 +26,7 @@ ProjectionPropagationModule::ProjectionPropagationModule(Configuration& config,
     model_ = detector_->getModel();
 
     // Require deposits message for single detector
-    messenger_->bindSingle<ProjectionPropagationModule, DepositedChargeMessage, MsgFlags::REQUIRED>(this);
+    messenger_->bindSingle<ProjectionPropagationModule, DepositedChargeMessage>(this);
 
     // Set default value for config variables
     config_.setDefault<int>("charge_per_step", 10);
@@ -226,4 +226,15 @@ void ProjectionPropagationModule::finalize() {
         // Write output plot
         drift_time_histo_->Write();
     }
+}
+
+// check if the required messages are present in the event
+bool ProjectionPropagationModule::isSatisfied(Event* event) const {
+    try {
+        auto deposits_message = event->fetchMessage<DepositedChargeMessage>();
+    } catch (std::out_of_range&) {
+        return false;
+    }
+
+    return true;
 }

--- a/src/modules/ProjectionPropagation/ProjectionPropagationModule.hpp
+++ b/src/modules/ProjectionPropagation/ProjectionPropagationModule.hpp
@@ -56,6 +56,12 @@ namespace allpix {
          */
         void finalize() override;
 
+        /**
+         * @brief Checks if the module is ready to run in the given event
+         * @param Event pointer to the event the module will run
+         */
+        virtual bool isSatisfied(Event* event) const;
+
     private:
         Messenger* messenger_;
         std::shared_ptr<const Detector> detector_;

--- a/src/modules/ProjectionPropagation/ProjectionPropagationModule.hpp
+++ b/src/modules/ProjectionPropagation/ProjectionPropagationModule.hpp
@@ -60,7 +60,7 @@ namespace allpix {
          * @brief Checks if the module is ready to run in the given event
          * @param Event pointer to the event the module will run
          */
-        virtual bool isSatisfied(Event* event) const;
+        virtual bool isSatisfied(Event* event) const override;
 
     private:
         Messenger* messenger_;

--- a/src/modules/RCEWriter/RCEWriterModule.cpp
+++ b/src/modules/RCEWriter/RCEWriterModule.cpp
@@ -415,3 +415,14 @@ void RCEWriterModule::finalize() {
     output_file_->Write();
     LOG(TRACE) << "Wrote data to file";
 }
+
+// check if the required messages are present in the event
+bool RCEWriterModule::isSatisfied(Event* event) const {
+    try {
+        auto pixel_hit_messages = event->fetchMultiMessage<PixelHitMessage>();
+    } catch (std::out_of_range&) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/modules/RCEWriter/RCEWriterModule.hpp
+++ b/src/modules/RCEWriter/RCEWriterModule.hpp
@@ -65,7 +65,7 @@ namespace allpix {
          * @brief Checks if the module is ready to run in the given event
          * @param Event pointer to the event the module will run
          */
-        virtual bool isSatisfied(Event* event) const;
+        virtual bool isSatisfied(Event* event) const override;
 
     private:
         GeometryManager* geo_mgr_;

--- a/src/modules/RCEWriter/RCEWriterModule.hpp
+++ b/src/modules/RCEWriter/RCEWriterModule.hpp
@@ -61,6 +61,12 @@ namespace allpix {
          */
         void finalize() override;
 
+        /**
+         * @brief Checks if the module is ready to run in the given event
+         * @param Event pointer to the event the module will run
+         */
+        virtual bool isSatisfied(Event* event) const;
+
     private:
         GeometryManager* geo_mgr_;
 

--- a/src/modules/ROOTObjectWriter/ROOTObjectWriterModule.cpp
+++ b/src/modules/ROOTObjectWriter/ROOTObjectWriterModule.cpp
@@ -282,3 +282,14 @@ void ROOTObjectWriterModule::finalize() {
     LOG(STATUS) << "Wrote " << write_cnt_ << " objects to " << branch_count << " branches in file:" << std::endl
                 << output_file_name_;
 }
+
+// check if the required messages are present in the event
+bool ROOTObjectWriterModule::isSatisfied(Event* event) const {
+    try {
+        auto messages = event->fetchFilteredMessages();
+    } catch (std::out_of_range&) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/modules/ROOTObjectWriter/ROOTObjectWriterModule.hpp
+++ b/src/modules/ROOTObjectWriter/ROOTObjectWriterModule.hpp
@@ -69,7 +69,7 @@ namespace allpix {
          * @brief Checks if the module is ready to run in the given event
          * @param Event pointer to the event the module will run
          */
-        virtual bool isSatisfied(Event* event) const;
+        virtual bool isSatisfied(Event* event) const override;
 
     private:
         void pre_run(Event*) const;

--- a/src/modules/ROOTObjectWriter/ROOTObjectWriterModule.hpp
+++ b/src/modules/ROOTObjectWriter/ROOTObjectWriterModule.hpp
@@ -65,6 +65,12 @@ namespace allpix {
          */
         void finalize() override;
 
+        /**
+         * @brief Checks if the module is ready to run in the given event
+         * @param Event pointer to the event the module will run
+         */
+        virtual bool isSatisfied(Event* event) const;
+
     private:
         void pre_run(Event*) const;
 

--- a/src/modules/SimpleTransfer/SimpleTransferModule.cpp
+++ b/src/modules/SimpleTransfer/SimpleTransferModule.cpp
@@ -47,7 +47,7 @@ SimpleTransferModule::SimpleTransferModule(Configuration& config, Messenger* mes
     output_plots_ = config_.get<bool>("output_plots");
 
     // Require propagated deposits for single detector
-    messenger->bindSingle<SimpleTransferModule, PropagatedChargeMessage, MsgFlags::REQUIRED>(this);
+    messenger->bindSingle<SimpleTransferModule, PropagatedChargeMessage>(this);
 }
 
 void SimpleTransferModule::init(std::mt19937_64&) {
@@ -168,4 +168,15 @@ void SimpleTransferModule::finalize() {
     if(output_plots_) {
         drift_time_histo->Write();
     }
+}
+
+// check if the required messages are present in the event
+bool SimpleTransferModule::isSatisfied(Event* event) const {
+    try {
+        auto propagated_message = event->fetchMessage<PropagatedChargeMessage>();
+    } catch (std::out_of_range&) {
+        return false;
+    }
+
+    return true;
 }

--- a/src/modules/SimpleTransfer/SimpleTransferModule.hpp
+++ b/src/modules/SimpleTransfer/SimpleTransferModule.hpp
@@ -63,7 +63,7 @@ namespace allpix {
          * @brief Checks if the module is ready to run in the given event
          * @param Event pointer to the event the module will run
          */
-        virtual bool isSatisfied(Event* event) const;
+        virtual bool isSatisfied(Event* event) const override;
 
     private:
         std::shared_ptr<Detector> detector_;

--- a/src/modules/SimpleTransfer/SimpleTransferModule.hpp
+++ b/src/modules/SimpleTransfer/SimpleTransferModule.hpp
@@ -59,6 +59,12 @@ namespace allpix {
          */
         void finalize() override;
 
+        /**
+         * @brief Checks if the module is ready to run in the given event
+         * @param Event pointer to the event the module will run
+         */
+        virtual bool isSatisfied(Event* event) const;
+
     private:
         std::shared_ptr<Detector> detector_;
         std::shared_ptr<DetectorModel> model_;

--- a/src/modules/TextWriter/TextWriterModule.cpp
+++ b/src/modules/TextWriter/TextWriterModule.cpp
@@ -143,3 +143,14 @@ void TextWriterModule::finalize() {
     LOG(STATUS) << "Wrote " << write_cnt_ << " objects from " << msg_cnt_ << " messages to file:" << std::endl
                 << output_file_name_;
 }
+
+// check if the required messages are present in the event
+bool TextWriterModule::isSatisfied(Event* event) const {
+    try {
+        auto messages = event->fetchFilteredMessages();
+    } catch (std::out_of_range&) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/modules/TextWriter/TextWriterModule.hpp
+++ b/src/modules/TextWriter/TextWriterModule.hpp
@@ -65,7 +65,7 @@ namespace allpix {
          * @brief Checks if the module is ready to run in the given event
          * @param Event pointer to the event the module will run
          */
-        virtual bool isSatisfied(Event* event) const;
+        virtual bool isSatisfied(Event* event) const override;
 
     private:
         // Object names to include or exclude from writing

--- a/src/modules/TextWriter/TextWriterModule.hpp
+++ b/src/modules/TextWriter/TextWriterModule.hpp
@@ -61,6 +61,12 @@ namespace allpix {
          */
         void finalize() override;
 
+        /**
+         * @brief Checks if the module is ready to run in the given event
+         * @param Event pointer to the event the module will run
+         */
+        virtual bool isSatisfied(Event* event) const;
+
     private:
         // Object names to include or exclude from writing
         std::set<std::string> include_;


### PR DESCRIPTION
This pull request attempt to patch the current messenger implementation to allow modules to register to multiple message types at the same time.

The meaning of the messenger class changed from a message broker to a kind of a mailbox where it just keeps the messages until the receiver asks for them.

The stored messages now in the messenger are not only identified by the module unique name but also by the message type_index; this way a module can receive multiple types.

This, however, will break the check if the module has received the required messages or not and required to refactor this check and move it directly to the module itself.

A new method for the module interface `isSatisfied` will check if the module received the required messages or not.

Note that the message flags are now useless because we can't tell from the messenger or the delegates if the module is satisfied or not.