### PR TITLE
fix CMake Error with HDF5 enabled Geant4 installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The following authors, in alphabetical order, have contributed to Allpix<sup>2</
 * Lennart Huth, DESY, @lhuth
 * Maoqiang Jing, University of South China, Institute of High Energy Physics Beijing, @mjing
 * Moritz Kiehn, Université de Genève, @msmk
+* Stephan Lachnit, Heidelberg University, @stephanlachnit
 * Salman Maqbool, CERN Summer Student, @smaqbool
 * Sebastien Murphy, ETHZ, @smurphy
 * Andreas Matthias Nürnberg, KIT, @nurnberg

--- a/src/modules/DepositionGeant4/CMakeLists.txt
+++ b/src/modules/DepositionGeant4/CMakeLists.txt
@@ -1,6 +1,9 @@
 # Define module
 ALLPIX_UNIQUE_MODULE(MODULE_NAME)
 
+# Required for CMake when Geant4 has HDF5 enabled
+ENABLE_LANGUAGE(C)
+
 # Geant4 is required for geometry description and charge deposition.
 FIND_PACKAGE(Geant4)
 IF(NOT Geant4_FOUND)


### PR DESCRIPTION
This is required when having an HDF5 enabled Geant4 installation. Without, CMake won't configure the project:

```
CMake Error at /usr/share/cmake-3.18/Modules/FindHDF5.cmake:225 (try_compile):
  Unknown extension ".c" for file

    /home/stephan/Projects/allpix-squared/build/src/modules/DepositionGeant4/CMakeFiles/hdf5/cmake_hdf5_test.c

  try_compile() works only for enabled languages.  Currently these are:

    CXX NONE

  See project() command to enable other languages.
```

I'm not entirely sure if this is the right place to add this, could also be a bug from Geant4 (not a CMake expert).