### PR TITLE
DepositionReader: fix parent ID relation

### DIFF
--- a/src/modules/DepositionReader/DepositionReaderModule.cpp
+++ b/src/modules/DepositionReader/DepositionReaderModule.cpp
@@ -317,8 +317,11 @@ void DepositionReaderModule::run(Event* event) {
                        << Units::display(time_reference, {"ns", "ps"}) << " global";
         }
 
+        auto mc_particle_size = mc_particle_start[detector].size();
         std::vector<MCParticle> mc_particles;
-        for(size_t i = 0; i < mc_particle_start[detector].size(); i++) {
+        mc_particles.reserve(mc_particle_size);
+
+        for(size_t i = 0; i < mc_particle_size; i++) {
             auto start_global = mc_particle_start[detector].at(i);
             auto start_local = detector->getLocalPosition(start_global);
             auto end_global = mc_particle_end[detector].at(i);


### PR DESCRIPTION
Closes #23 

@simonspa I found a way simpler fix. If we reserve the needed space for the vector beforehand, nothing will be moved at all since MCParticle is fixed in size. I tried it with a couple of events and it correctly only found one unknown particle ID (the radioactive ion).