### PR TITLE
CSADigitizer: last threshold crossing for ToT

### DIFF
--- a/etc/unittests/test_modules/test_06-11_digitization_csa_last_threshold_crossing_tot.conf
+++ b/etc/unittests/test_modules/test_06-11_digitization_csa_last_threshold_crossing_tot.conf
@@ -1,0 +1,33 @@
+[Allpix]
+detectors_file = "detector.conf"
+number_of_events = 1
+random_seed = 0
+
+[DepositionPointCharge]
+model = "fixed"
+source_type = "point"
+position = 445um 220um 0um
+number_of_charges = 1000
+
+[ElectricFieldReader]
+model = "linear"
+bias_voltage = 100V
+depletion_voltage = 150V
+
+[GenericPropagation]
+temperature = 293K
+charge_per_step = 100
+propagate_electrons = false
+propagate_holes = true
+
+[PulseTransfer]
+
+[CSADigitizer]
+log_level = DEBUG
+model = "simple"
+clock_bin_toa = 1ns
+clock_bin_tot = 5ns
+sigma_noise = 5mV
+last_threshold_crossing_tot = true
+
+#PASS [R:CSADigitizer:mydetector] Pixel (2,0): time 13clk, signal 14clk

--- a/src/modules/CSADigitizer/CSADigitizerModule.cpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.cpp
@@ -411,8 +411,10 @@ unsigned int CSADigitizerModule::get_tot(double timestep, double arrival_time, c
             if(!last_threshold_crossing_tot_) {
                 break;
             }
+            was_above_treshold = false;
+        } else if(!was_above_treshold && !is_below_threshold) {
+            was_above_treshold = true;
         }
-        was_above_treshold = !is_below_threshold;
         tot_clock_cycles++;
         tot_time += clockToT_;
     }

--- a/src/modules/CSADigitizer/CSADigitizerModule.hpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.hpp
@@ -81,6 +81,7 @@ namespace allpix {
 
         // Parameters of the electronics: Noise, time-over-threshold logic
         double sigmaNoise_{}, clockToT_{}, clockToA_{}, threshold_{};
+        bool last_threshold_crossing_tot_{};
 
         // Helper variables for transfer function
         double integration_time_{};

--- a/src/modules/CSADigitizer/README.md
+++ b/src/modules/CSADigitizer/README.md
@@ -23,6 +23,7 @@ The values stored in `PixelHit` depend on the Time-of-Arrival (ToA) and Time-ove
 Since the input pulse may have different polarity, it is important to set the threshold accordingly to a positive or negative value, otherwise it may not trigger at all.
 If this behavior is not desired, the `ignore_polarity` parameter can be set to compare only the absolute values of the input and the threshold value.
 
+By default, the first crossing from above to below the threshold is used to determine the ToT. Some chips may use the last crossing for better performance in high noise to signal scenarios, which can be adjusted with the `last_threshold_crossing_tot` parameter.
 
 ### Parameters
 * `model` : Choice between different CSA models. Currently implemented are two parametrizations of the circuit from [@kleczek], `simple` and `csa`, and the `custom` model for a custom impulse response.
@@ -30,6 +31,7 @@ If this behavior is not desired, the `ignore_polarity` parameter can be set to c
 * `sigma_noise` : Standard deviation of the Gaussian-distributed noise added to the output signal. Defaults to 0.1 mV.
 * `threshold` : Threshold for TOT/TOA logic, for considering the output signal as a hit. Defaults to 10mV.
 * `ignore_polarity`: Select whether polarity of the threshold is ignored, i.e. the absolute values are compared, or if polarity is taken into account. Defaults to `false`.
+* `last_threshold_crossing_tot` : Select whether the last threshold crossing should be used as ToT within the integration time. Defaults to `false`. 
 * `clock_bin_toa` : Duration of a clock cycle for the time-of-arrival (ToA) clock. If set, the output timestamp is delivered in units of ToA clock cycles, otherwise in nanoseconds.
 * `clock_bin_tot` : Duration of a clock cycle for the time-over-threshold (ToT) clock. If set, the output charge is delivered as time over threshold in units of ToT clock cycles, otherwise the pulse integral is stored instead.
 
@@ -94,6 +96,7 @@ model = "custom"
 response_function = "TMath::Max([0]*(1.-TMath::Exp(-x/[1]))-[2]*x,0.)"
 response_parameters = [2.6e14V/C, 9.1e1ns, 4.2e19V/C/s]
 integration_time = 10us
+last_threshold_crossing_tot = true
 threshold = 60mV
 clock_bin_toa = 8ns
 clock_bin_tot = 8ns


### PR DESCRIPTION
This PR aims to add an option to allow to use the last threshold crossing in the ToT measurement to determine the ToT. This is the behavior on the MuPix10 and allows better precision in high noise to signal scenarios.

To demonstrate the difference, this plot was made in a high noise scenario (Fe55) with a MuPix10 parameterization:

![new_tot_mode](https://user-images.githubusercontent.com/36662302/115856139-65e5b000-a42c-11eb-8b0e-11a53ea85985.png)

The current implementation has two problems:
- no option to enable or disable the mode right now
- currently this is bound to the integration time, which is bad since we ideally want this to be a certain amount of time after the ToA, i.e. some max amounts of clock cycles where it stops

Regarding the second one:
I think it would be best to introduce two integration times: a ToA integration time, and a ToT integration time. First, we amplify the pulse only for the ToA integration time. If we get a signal, then we amplify again so that we end up at the ToT integration time.

The simpler alternative would be to just define a ToT integration time, and stop when `time - toa_time > tot_time`. The problem here is that we can't ensure that the pulse is amplified long enough (imagine the integration time is 1us and the ToT integration time 100ns, but the ToA time is 950ns). To prevent this we would need a relatively high base integration time.

Regarding the first one:
This behavior, no matter which option, should definitely be optional as is it costs some performance, and also maybe other chips don't have this behavior. I haven't run benchmarks (yet), but it felt not insignificant. With the first option, I propose this interface:
```config
tot_last_crossing = true
toa_integration_time = 1us
tot_integration_time = 1us
```
If `tot_last_crossing` is false, the interface would stay just as before.

For the second option, one can simply use
```config
last_crossing_integration_time = 1us
```
If this variable is set, the new mode is enabled, else it is not.


Any thoughts / feedback?