### PR TITLE
Add MuPixDigitizer module

### DIFF
--- a/.github/workflows/compilation-and-test.yml
+++ b/.github/workflows/compilation-and-test.yml
@@ -1,4 +1,4 @@
-name: github-ci
+name: compile&test
 on:
   pull_request:
     types: [opened, reopened, edited, ready_for_review, synchronize]
@@ -110,20 +110,3 @@ jobs:
           chmod a+x bin/allpix
           cd build
           ctest -R ${{matrix.whichtest}} --output-on-failure -j4
-
-  format:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
-    - uses: aidasoft/run-lcg-view@v2
-      with:
-        run_local_checkout: 'false'
-        release-platform: "${{env.LCG_VERSION}}/x86_64-centos7-clang10-opt"
-        run: |
-          mkdir build
-          cd build
-          cmake -GNinja -DCMAKE_CXX_FLAGS="-Werror" -DBUILD_LCIOWriter=ON -DCMAKE_BUILD_TYPE=RELEASE -DLCIO_DIR=$LCIO_DIR ..
-          ninja check-format

--- a/.github/workflows/format-and-lint.yml
+++ b/.github/workflows/format-and-lint.yml
@@ -1,0 +1,60 @@
+name: format&lint
+on:
+  pull_request:
+    types: [opened, reopened, edited, ready_for_review, synchronize]
+env:
+  LCG_VERSION: LCG_99
+jobs:
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: aidasoft/run-lcg-view@v2
+      with:
+        run_local_checkout: 'false'
+        release-platform: "${{env.LCG_VERSION}}/x86_64-centos7-clang10-opt"
+        run: |
+          mkdir build
+          cd build
+          cmake -GNinja -DCMAKE_CXX_FLAGS="-Werror" -DBUILD_LCIOWriter=ON -DCMAKE_BUILD_TYPE=RELEASE -DLCIO_DIR=$LCIO_DIR ..
+          ninja check-format
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: aidasoft/run-lcg-view@v2
+      with:
+        run_local_checkout: 'false'
+        release-platform: "${{env.LCG_VERSION}}/x86_64-centos7-clang10-opt"
+        run: |
+          mkdir build
+          cd build
+          cmake -GNinja -DCMAKE_CXX_FLAGS="-Werror" -DBUILD_LCIOWriter=ON -DCMAKE_BUILD_TYPE=RELEASE -DLCIO_DIR=$LCIO_DIR ..
+          ninja check-lint
+
+  cmake-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: aidasoft/run-lcg-view@v2
+      with:
+        run_local_checkout: 'false'
+        release-platform: "${{env.LCG_VERSION}}/x86_64-centos7-clang10-opt"
+        run: |
+          mkdir build
+          cd build
+          export PATH=$PATH:~/.local/bin
+          pip install --trusted-host=pypi.org --user cmakelang
+          cmake -GNinja ..
+          ninja lint-cmake

--- a/src/modules/DepositionGeant4/DepositionGeant4Module.cpp
+++ b/src/modules/DepositionGeant4/DepositionGeant4Module.cpp
@@ -391,9 +391,12 @@ void DepositionGeant4Module::construct_sensitive_detectors_and_fields(double fan
         }
         useful_deposition = true;
 
+        // Get the hit transformation matrix
+        auto* hit_transform = calculate_hit_transform(detector->getModel());
+
         // Get model of the sensitive device
         auto* sensitive_detector_action = new SensitiveDetectorActionG4(
-            detector, track_info_manager_.get(), charge_creation_energy, fano_factor, cutoff_time);
+            detector, track_info_manager_.get(), hit_transform, charge_creation_energy, fano_factor, cutoff_time);
         auto logical_volume = geo_manager_->getExternalObject<G4LogicalVolume>(detector->getName(), "sensor_log");
         if(logical_volume == nullptr) {
             throw ModuleError("Detector " + detector->getName() + " has no sensitive device (broken Geant4 geometry)");
@@ -443,4 +446,8 @@ void DepositionGeant4Module::record_module_statistics() {
     for(auto& sensor : sensors_) {
         total_charges_ += sensor->getTotalDepositedCharge();
     }
+}
+
+G4RotationMatrix* DepositionGeant4Module::calculate_hit_transform(const std::shared_ptr<DetectorModel>&) {
+    return new G4RotationMatrix();
 }

--- a/src/modules/DepositionGeant4/DepositionGeant4Module.hpp
+++ b/src/modules/DepositionGeant4/DepositionGeant4Module.hpp
@@ -92,6 +92,16 @@ namespace allpix {
          */
         void record_module_statistics();
 
+        /**
+         * @brief Calculate hit transformation matrix for a given detector model
+         * @param model Detector model
+         * @returns Hit transformation matrix pointer
+         *
+         * @note This matrix transforms the Geant4 local coordinate system of the sensor
+         * volume to the APSQ local coordinate system based on the detector model type.
+         */
+        G4RotationMatrix* calculate_hit_transform(const std::shared_ptr<DetectorModel>& model);
+
         Messenger* messenger_;
         GeometryManager* geo_manager_;
 

--- a/src/modules/DepositionGeant4/SensitiveDetectorActionG4.cpp
+++ b/src/modules/DepositionGeant4/SensitiveDetectorActionG4.cpp
@@ -36,6 +36,7 @@ using namespace allpix;
 
 SensitiveDetectorActionG4::SensitiveDetectorActionG4(const std::shared_ptr<Detector>& detector,
                                                      TrackInfoManager* track_info_manager,
+                                                     const G4RotationMatrix* hit_transform,
                                                      double charge_creation_energy,
                                                      double fano_factor,
                                                      double cutoff_time)
@@ -46,6 +47,8 @@ SensitiveDetectorActionG4::SensitiveDetectorActionG4(const std::shared_ptr<Detec
     // Add the sensor to the internal sensitive detector manager
     G4SDManager* sd_man_g4 = G4SDManager::GetSDMpointer();
     sd_man_g4->AddNewDetector(this);
+
+    hit_transform_ = hit_transform;
 }
 
 G4bool SensitiveDetectorActionG4::ProcessHits(G4Step* step, G4TouchableHistory*) {
@@ -73,6 +76,9 @@ G4bool SensitiveDetectorActionG4::ProcessHits(G4Step* step, G4TouchableHistory*)
     // Calculate the charge deposit at a local position
     auto deposit_position = detector_->getLocalPosition(static_cast<ROOT::Math::XYZPoint>(step_pos));
     auto deposit_position_g4 = theTouchable->GetHistory()->GetTopTransform().TransformPoint(step_pos);
+
+    // Transform the hit position using the rotation matrix
+    deposit_position_g4 *= *hit_transform_;
 
     // Calculate number of electron hole pairs produced, taking into account fluctuations between ionization and lattice
     // excitations via the Fano factor. We assume Gaussian statistics here.

--- a/src/modules/DepositionGeant4/SensitiveDetectorActionG4.hpp
+++ b/src/modules/DepositionGeant4/SensitiveDetectorActionG4.hpp
@@ -36,12 +36,14 @@ namespace allpix {
          * @brief Constructs the action handling for every sensitive detector
          * @param detector Detector this sensitive device is bound to
          * @param track_info_manager Pointer to the track information manager
+         * @param hit_transform Pointer to the hit transformation matrix
          * @param charge_creation_energy Energy needed per deposited charge
          * @param fano_factor Fano factor for fluctuations in the energy fraction going into e/h pair creation
          * @param cutoff_time Cut-off time for the creation of secondary particles
          */
         SensitiveDetectorActionG4(const std::shared_ptr<Detector>& detector,
                                   TrackInfoManager* track_info_manager,
+                                  const G4RotationMatrix* hit_transform,
                                   double charge_creation_energy,
                                   double fano_factor,
                                   double cutoff_time);
@@ -124,6 +126,8 @@ namespace allpix {
         std::vector<int> deposit_to_id_;
         // Map from track id to mc particle index
         std::map<int, size_t> id_to_particle_;
+
+        const G4RotationMatrix* hit_transform_;
     };
 } // namespace allpix
 

--- a/src/modules/MuPixDigitizer/CMakeLists.txt
+++ b/src/modules/MuPixDigitizer/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Define module
+ALLPIX_DETECTOR_MODULE(MODULE_NAME)
+
+# Add source files to module
+ALLPIX_MODULE_SOURCES(
+    ${MODULE_NAME}
+    MuPixDigitizerModule.cpp
+    MuPixModel.cpp
+    Models/MuPix10.cpp
+    Models/MuPix10Double.cpp
+    Models/MuPix10Ramp.cpp
+)
+
+# Provide standard install target
+ALLPIX_MODULE_INSTALL(${MODULE_NAME})

--- a/src/modules/MuPixDigitizer/Models/MuPix10.cpp
+++ b/src/modules/MuPixDigitizer/Models/MuPix10.cpp
@@ -1,0 +1,117 @@
+/**
+ * @file
+ * @brief Definition of MuPix10 for the MuPix digitizer module
+ * @copyright Copyright (c) 2021 CERN and the Allpix Squared authors.
+ * This software is distributed under the terms of the MIT License, copied verbatim in the file "LICENSE.md".
+ * In applying this license, CERN does not waive the privileges and immunities granted to it by virtue of its status as an
+ * Intergovernmental Organization or submit itself to any jurisdiction.
+ */
+
+#include "MuPix10.hpp"
+
+#include <algorithm>
+#include <iterator>
+#include <numeric>
+
+#include "tools/ROOT.h"
+
+using namespace allpix::mupix;
+
+MuPix10::MuPix10(Configuration& config) : MuPixModel(config) {
+    // Set default parameters
+    config.setDefault<double>("A_m", Units::get(0.01, "mV/e"));
+    config.setDefault<double>("A_c", Units::get(90., "mV"));
+    config.setDefault<double>("A_mu", Units::get(3400., "e"));
+    config.setDefault<double>("t_R", Units::get(0.1, "us"));
+    config.setDefault<double>("t_F", Units::get(4.8, "us"));
+    config.setDefault<double>("t_S", Units::get(0.1, "us"));
+    config.setDefault<double>("Fb", Units::get(23., "mV/us"));
+    config.setDefault<double>("Fb_D", Units::get(2., "mV"));
+    config.setDefault<double>("U_sat", Units::get(360., "mV"));
+    config.setDefault<double>("pulse_cutoff_time", Units::get(1., "ns"));
+
+    // Get parameters
+    A_m_ = config.get<double>("A_m");
+    A_c_ = config.get<double>("A_c");
+    A_mu_ = config.get<double>("A_mu");
+    t_R_ = config.get<double>("t_R");
+    t_F_ = config.get<double>("t_F");
+    t_S_ = config.get<double>("t_S");
+    Fb_ = config.get<double>("Fb");
+    Fb_D_ = config.get<double>("Fb_D");
+    U_sat_ = config.get<double>("U_sat");
+    pulse_cutoff_time_ = config.get<double>("pulse_cutoff_time");
+
+    LOG(DEBUG) << "Initialized MuPix10 configuration with " << Units::display(pulse_cutoff_time_, "ns")
+               << " charge pulse cutoff"
+               << ", A_m=" << Units::display(A_m_, "mV/e") << ", A_c=" << Units::display(A_c_, "mV")
+               << ", A_mu=" << Units::display(A_mu_, "e") << ", t_R=" << Units::display(t_R_, "us")
+               << ", t_F=" << Units::display(t_F_, "us") << ", t_S=" << Units::display(t_S_, "us")
+               << ", Fb=" << Units::display(Fb_, "mV/us") << ", Fb_D=" << Units::display(Fb_D_, "mV")
+               << ", U_sat=" << Units::display(U_sat_, "mV");
+}
+
+std::vector<double> MuPix10::amplify_pulse(const Pulse& pulse) const {
+    LOG(TRACE) << "Amplifying pulse";
+
+    // Create output vector
+    auto timestep = pulse.getBinning();
+    auto max_pulse_bins = static_cast<ptrdiff_t>(pulse_cutoff_time_ / timestep);
+    auto ntimepoints = static_cast<size_t>(ceil(integration_time_ / timestep));
+    std::vector<double> amplified_pulse_vec(ntimepoints, 0.);
+
+    // Cut pulse for specified time
+    auto pulse_vec = pulse.getPulse();
+    auto pulse_vec_first = std::find_if(pulse_vec.begin(), pulse_vec.end(), [](auto& c) { return c > 0.; });
+    auto pulse_vec_last = (std::distance(pulse_vec_first, pulse_vec.end()) < max_pulse_bins)
+                              ? pulse_vec.end()
+                              : std::next(pulse_vec_first, max_pulse_bins);
+
+    // Assume pulse is delta peak with all charges at the maximum
+    auto charge = std::accumulate(pulse_vec_first, pulse_vec_last, 0.);
+    auto kmin = static_cast<size_t>(std::distance(pulse_vec.begin(), pulse_vec_first));
+
+    // Prepare variables for amplification
+    double U_out = 0.;
+    auto A = (A_m_ * charge + A_c_) * (1. - exp(-charge / A_mu_));
+    double rcshaper_t_k = 0.;
+    double rcshaper_t_k_m1 = 0.;
+
+    // Lambda for amplification
+    auto amplification = [=](double t) { return A * (exp(-t / t_F_) - exp(-t / t_R_)) * (1. - exp(-t / t_S_)); };
+
+    // Lambda for feedback
+    auto feedback = [=](double U) { return Fb_ * (1. - exp(-U / Fb_D_)); };
+
+    // Lambda for saturation
+    auto saturation = [=](double U) { return U_sat_ * (2. / (1. + exp(-2. * U / U_sat_)) - 1.); };
+
+    // Log some useful information
+    LOG(DEBUG) << "Amplifying pulse with effective charge " << Units::display(charge, "e") << " arriving at "
+               << Units::display(static_cast<double>(kmin) * timestep, "ns") << ", A = " << Units::display(A, "mV");
+
+    // Set output to zero before pulse arrives
+    std::fill_n(amplified_pulse_vec.begin(), kmin, 0.);
+
+    // Calculate output starting relative to arrival
+    for(size_t k = kmin; k < ntimepoints; ++k) {
+        // Add voltage from RC shaper
+        rcshaper_t_k = amplification(static_cast<double>(k - kmin) * timestep);
+        U_out += rcshaper_t_k - rcshaper_t_k_m1;
+
+        // Apply feedback
+        U_out -= feedback(U_out) * timestep;
+
+        // Store output
+        amplified_pulse_vec.at(k) = U_out;
+        rcshaper_t_k_m1 = rcshaper_t_k;
+    }
+
+    // Apply saturation
+    std::transform(amplified_pulse_vec.begin(),
+                   amplified_pulse_vec.end(),
+                   amplified_pulse_vec.begin(),
+                   [&saturation](auto& c) { return saturation(c); });
+
+    return amplified_pulse_vec;
+}

--- a/src/modules/MuPixDigitizer/Models/MuPix10.hpp
+++ b/src/modules/MuPixDigitizer/Models/MuPix10.hpp
@@ -1,0 +1,48 @@
+/**
+ * @file
+ * @brief Definition of MuPix10 for the MuPix digitizer module
+ * @copyright Copyright (c) 2021 CERN and the Allpix Squared authors.
+ * This software is distributed under the terms of the MIT License, copied verbatim in the file "LICENSE.md".
+ * In applying this license, CERN does not waive the privileges and immunities granted to it by virtue of its status as an
+ * Intergovernmental Organization or submit itself to any jurisdiction.
+ */
+
+#ifndef ALLPIX_MUPIX10_H
+#define ALLPIX_MUPIX10_H
+
+#include "MuPixModel.hpp"
+
+namespace allpix {
+    namespace mupix {
+        /**
+         * @brief Implementation of MuPix10 with a single threshold
+         *
+         * This class uses all reference functions. It implements a triangular
+         * impulse response function for the amplification.
+         */
+        class MuPix10 : public MuPixModel {
+        public:
+            MuPix10(Configuration& config);
+
+            std::vector<double> amplify_pulse(const Pulse& pulse) const;
+
+        protected:
+            // Cutoff time for pulse
+            double pulse_cutoff_time_{};
+
+            // Charge amplification parameters
+            double A_m_{}, A_c_{}, A_mu_{};
+
+            // Amplification shaping parameters
+            double t_R_{}, t_F_{}, t_S_{};
+
+            // Feedback parameters
+            double Fb_{}, Fb_D_{};
+
+            // Saturation parameters
+            double U_sat_{};
+        };
+    } // namespace mupix
+} // namespace allpix
+
+#endif /* ALLPIX_MUPIX10_H */

--- a/src/modules/MuPixDigitizer/Models/MuPix10Double.cpp
+++ b/src/modules/MuPixDigitizer/Models/MuPix10Double.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file
+ * @brief Definition of MuPix10 with second threshold for the MuPix digitizer module
+ * @copyright Copyright (c) 2021 CERN and the Allpix Squared authors.
+ * This software is distributed under the terms of the MIT License, copied verbatim in the file "LICENSE.md".
+ * In applying this license, CERN does not waive the privileges and immunities granted to it by virtue of its status as an
+ * Intergovernmental Organization or submit itself to any jurisdiction.
+ */
+
+#include "MuPix10Double.hpp"
+
+#include <cmath>
+
+using namespace allpix::mupix;
+
+MuPix10Double::MuPix10Double(Configuration& config) : MuPix10(config) {
+    // Set default config values
+    config.setDefault<double>("threshold_high", Units::get(40, "mV"));
+
+    // Get config values
+    threshold_high_ = config.get<double>("threshold_high");
+}
+
+std::tuple<bool, unsigned int> MuPix10Double::get_ts1(double timestep, const std::vector<double>& pulse) const {
+    auto th_low_result = MuPix10::get_ts1(timestep, pulse);
+
+    if(!std::get<0>(th_low_result)) {
+        return th_low_result;
+    }
+
+    // Lambda for threshold calculation
+    auto calculate_is_above_threshold_high = [=](double bin) {
+        return (threshold_high_ > 0. ? bin > threshold_high_ : bin < threshold_high_);
+    };
+
+    // Same as MuPixModel::get_ts1, just for high threshold
+    bool th_high_crossed = false;
+    auto ts1_th_high_clock_cycles = std::get<1>(th_low_result);
+    auto max_ts1_th_high_clock_cycles = static_cast<unsigned int>(std::ceil(integration_time_ / ts1_clock_));
+    while(ts1_th_high_clock_cycles < max_ts1_th_high_clock_cycles) {
+        auto bin = pulse.at(static_cast<size_t>(std::floor(ts1_th_high_clock_cycles * ts1_clock_ / timestep)));
+        if(calculate_is_above_threshold_high(bin)) {
+            th_high_crossed = true;
+            break;
+        };
+        ts1_th_high_clock_cycles++;
+    }
+    return {th_high_crossed, std::get<1>(th_low_result)};
+}

--- a/src/modules/MuPixDigitizer/Models/MuPix10Double.hpp
+++ b/src/modules/MuPixDigitizer/Models/MuPix10Double.hpp
@@ -1,0 +1,40 @@
+/**
+ * @file
+ * @brief Definition of MuPix10 with second threshold for the MuPix digitizer module
+ * @copyright Copyright (c) 2021 CERN and the Allpix Squared authors.
+ * This software is distributed under the terms of the MIT License, copied verbatim in the file "LICENSE.md".
+ * In applying this license, CERN does not waive the privileges and immunities granted to it by virtue of its status as an
+ * Intergovernmental Organization or submit itself to any jurisdiction.
+ */
+
+#ifndef ALLPIX_MUPIX10_DOUBLE_H
+#define ALLPIX_MUPIX10_DOUBLE_H
+
+#include <tuple>
+#include <vector>
+
+#include "MuPix10.hpp"
+
+namespace allpix {
+    namespace mupix {
+        /**
+         * @brief Implementation of MuPix10 with a second threshold
+         *
+         * This class uses overwrites the TS1 calculation by setting the bool
+         * for the crossed signal only when it also crosses the higher
+         * threshold.
+         */
+        class MuPix10Double : public MuPix10 {
+        public:
+            MuPix10Double(Configuration& config);
+
+            std::tuple<bool, unsigned int> get_ts1(double timestep, const std::vector<double>& pulse) const;
+
+        protected:
+            // Second threshold
+            double threshold_high_{};
+        };
+    } // namespace mupix
+} // namespace allpix
+
+#endif /* ALLPIX_MUPIX10_DOUBLE_H */

--- a/src/modules/MuPixDigitizer/Models/MuPix10Ramp.cpp
+++ b/src/modules/MuPixDigitizer/Models/MuPix10Ramp.cpp
@@ -1,0 +1,60 @@
+/**
+ * @file
+ * @brief Definition of MuPix10 in ramp mode for the MuPix digitizer module
+ * @copyright Copyright (c) 2021 CERN and the Allpix Squared authors.
+ * This software is distributed under the terms of the MIT License, copied verbatim in the file "LICENSE.md".
+ * In applying this license, CERN does not waive the privileges and immunities granted to it by virtue of its status as an
+ * Intergovernmental Organization or submit itself to any jurisdiction.
+ */
+
+#include "MuPix10Ramp.hpp"
+
+#include <cmath>
+
+#include "core/messenger/Messenger.hpp"
+
+using namespace allpix::mupix;
+
+MuPix10Ramp::MuPix10Ramp(Configuration& config) : MuPix10(config) {
+    threshold_slew_rate_ = config.get<double>("threshold_slew_rate");
+}
+
+unsigned int MuPix10Ramp::get_ts2(unsigned int ts1, double timestep, const std::vector<double>& pulse) const {
+    // Same as MuPixModel::get_ts2, just with dynamic threshold
+    LOG(TRACE) << "Calculating TS2";
+    bool was_above_treshold = true;
+    auto ts2_clock_cycles = static_cast<unsigned int>(std::ceil(ts1 * ts1_clock_ / ts2_clock_));
+    auto final_ts2_clock_cycles = ts2_clock_cycles;
+
+    // Calculate dynamic threshold for at beginning of cycle
+    double dynamic_threshold = threshold_ + threshold_slew_rate_ * (ts2_clock_cycles * ts2_clock_ - ts1 * ts1_clock_);
+
+    // Lambda for threshold calculation
+    auto calculate_is_below_threshold = [&](double bin) {
+        return (dynamic_threshold > 0 ? bin < dynamic_threshold : bin > dynamic_threshold);
+    };
+
+    // Calculate max TS2 clock cycles after TS1 (+1), or cap at integration time
+    auto max_ts2_time = std::min<double>(ts1 * ts1_clock_ + tot_cap_, integration_time_);
+    auto max_ts2_clock_cycles = static_cast<unsigned int>(std::ceil(max_ts2_time / ts2_clock_));
+
+    while(ts2_clock_cycles < max_ts2_clock_cycles) {
+        auto bin = pulse.at(static_cast<size_t>(std::floor(ts2_clock_cycles * ts2_clock_ / timestep)));
+        auto is_below_threshold = calculate_is_below_threshold(bin);
+        if(was_above_treshold && is_below_threshold) {
+            final_ts2_clock_cycles = ts2_clock_cycles;
+            was_above_treshold = false;
+        } else if(!was_above_treshold && !is_below_threshold) {
+            was_above_treshold = true;
+        }
+        dynamic_threshold += threshold_slew_rate_ * ts2_clock_;
+        ts2_clock_cycles++;
+    }
+
+    // Cap TS2 if pulse is above threshold at the end
+    if(was_above_treshold) {
+        final_ts2_clock_cycles = max_ts2_clock_cycles - 1;
+    }
+
+    return final_ts2_clock_cycles;
+}

--- a/src/modules/MuPixDigitizer/Models/MuPix10Ramp.hpp
+++ b/src/modules/MuPixDigitizer/Models/MuPix10Ramp.hpp
@@ -1,0 +1,38 @@
+/**
+ * @file
+ * @brief Definition of MuPix10 in ramp mode for the MuPix digitizer module
+ * @copyright Copyright (c) 2021 CERN and the Allpix Squared authors.
+ * This software is distributed under the terms of the MIT License, copied verbatim in the file "LICENSE.md".
+ * In applying this license, CERN does not waive the privileges and immunities granted to it by virtue of its status as an
+ * Intergovernmental Organization or submit itself to any jurisdiction.
+ */
+
+#ifndef ALLPIX_MUPIX10_RAMP_H
+#define ALLPIX_MUPIX10_RAMP_H
+
+#include <vector>
+
+#include "MuPix10.hpp"
+
+namespace allpix {
+    namespace mupix {
+        /**
+         * @brief Implementation of MuPix10 in ramp mode
+         *
+         * This class uses overwrites the TS2 calculation by changing the
+         * static threshold in the algorithm with a linear rising one.
+         */
+        class MuPix10Ramp : public MuPix10 {
+        public:
+            MuPix10Ramp(Configuration& config);
+
+            unsigned int get_ts2(unsigned int arrival, double timestep, const std::vector<double>& pulse) const;
+
+        protected:
+            // Parameters for dynamic threshold
+            double threshold_slew_rate_{};
+        };
+    } // namespace mupix
+} // namespace allpix
+
+#endif /* ALLPIX_MUPIX10_RAMP_H */

--- a/src/modules/MuPixDigitizer/MuPixDigitizerModule.cpp
+++ b/src/modules/MuPixDigitizer/MuPixDigitizerModule.cpp
@@ -1,0 +1,213 @@
+/**
+ * @file
+ * @brief Implementation of MuPix digitization module
+ * @copyright Copyright (c) 2021 CERN and the Allpix Squared authors.
+ * This software is distributed under the terms of the MIT License, copied verbatim in the file "LICENSE.md".
+ * In applying this license, CERN does not waive the privileges and immunities granted to it by virtue of its status as an
+ * Intergovernmental Organization or submit itself to any jurisdiction.
+ */
+
+#include "MuPixDigitizerModule.hpp"
+
+#include "core/utils/distributions.h"
+#include "core/utils/unit.h"
+#include "tools/ROOT.h"
+
+#include <TF1.h>
+#include <TFile.h>
+#include <TGraph.h>
+#include <TH1D.h>
+#include <TH1F.h>
+#include <TProfile.h>
+
+#include "objects/PixelHit.hpp"
+
+#include "Models/MuPix10.hpp"
+#include "Models/MuPix10Double.hpp"
+#include "Models/MuPix10Ramp.hpp"
+
+using namespace allpix;
+
+MuPixDigitizerModule::MuPixDigitizerModule(Configuration& config, Messenger* messenger, std::shared_ptr<Detector> detector)
+    : Module(config, std::move(detector)), messenger_(messenger) {
+
+    // Require PixelCharge message for single detector
+    messenger_->bindSingle<PixelChargeMessage>(this, MsgFlags::REQUIRED);
+
+    // Read model
+    auto model = config_.get<std::string>("model");
+    std::transform(model.begin(), model.end(), model.begin(), ::tolower);
+    if(model == "mupix10") {
+        model_ = std::make_unique<mupix::MuPix10>(config);
+    } else if(model == "mupix10double") {
+        model_ = std::make_unique<mupix::MuPix10Double>(config);
+    } else if(model == "mupix10ramp") {
+        model_ = std::make_unique<mupix::MuPix10Ramp>(config);
+    } else {
+        throw InvalidValueError(
+            config_, "model", "Invalid model, only 'mupix10', 'mupix10double' and 'mupix10ramp' are supported.");
+    }
+
+    // Set defaults for common config variables
+    config_.setDefault<double>("sigma_noise", Units::get(1, "mV"));
+    config_.setDefault<bool>("output_pulsegraphs", false);
+    config_.setDefault<bool>("output_plots", config_.get<bool>("output_pulsegraphs"));
+
+    // Get common config variables
+    sigmaNoise_ = config_.get<double>("sigma_noise");
+    output_plots_ = config_.get<bool>("output_plots");
+    output_pulsegraphs_ = config_.get<bool>("output_pulsegraphs");
+
+    // Enable multithreading of this module if multithreading is enabled and no per-event output plots are requested:
+    // FIXME: Review if this is really the case or we can still use multithreading
+    if(!output_pulsegraphs_) {
+        allow_multithreading();
+    } else {
+        LOG(WARNING) << "Per-event pulse graphs requested, disabling parallel event processing";
+    }
+}
+
+void MuPixDigitizerModule::initialize() {
+    if(output_plots_) {
+        LOG(TRACE) << "Creating output plots";
+
+        auto nbins_ts1 = static_cast<int>(std::ceil(model_->get_integration_time() / model_->get_ts1_clock()));
+        auto nbins_ts2 = static_cast<int>(std::ceil(model_->get_integration_time() / model_->get_ts2_clock()));
+        auto nbins_tot = static_cast<int>(std::ceil(model_->get_integration_time() / model_->get_ts1_clock()));
+
+        // Create histograms if needed
+        h_ts1 = CreateHistogram<TH1D>("ts1", "TS1;TS1 [clk];pixels", nbins_ts1, 0, nbins_ts1);
+        h_ts2 = CreateHistogram<TH1D>("ts2", "TS2;TS2 [clk];pixels", nbins_ts2, 0, nbins_ts2);
+        h_tot = CreateHistogram<TH1F>("tot", "ToT;TS2 - TS1 [ns];pixels", nbins_tot, 0, model_->get_integration_time());
+    }
+}
+
+void MuPixDigitizerModule::run(Event* event) {
+    auto pixel_message = messenger_->fetchMessage<PixelChargeMessage>(this, event);
+
+    // Loop through all pixels with charges
+    std::vector<PixelHit> hits;
+    for(const auto& pixel_charge : pixel_message->getData()) {
+        auto pixel = pixel_charge.getPixel();
+        auto pixel_index = pixel.getIndex();
+        auto inputcharge = static_cast<double>(pixel_charge.getCharge());
+
+        LOG(DEBUG) << "Received pixel " << pixel_index << ", charge " << Units::display(inputcharge, "e");
+
+        const auto& pulse = pixel_charge.getPulse(); // the pulse containing charges and times
+
+        if(!pulse.isInitialized()) {
+            throw ModuleError("No pulse information available.");
+        }
+
+        auto pulse_vec = pulse.getPulse(); // the vector of the charges
+        auto timestep = pulse.getBinning();
+
+        LOG(TRACE) << "Preparing pulse for pixel " << pixel_index << ", " << pulse_vec.size() << " bins of "
+                   << Units::display(timestep, {"ps", "ns"}) << ", total charge: " << Units::display(pulse.getCharge(), "e");
+
+        auto amplified_pulse_vec = model_->amplify_pulse(pulse);
+
+        if(output_pulsegraphs_) {
+            // Fill a graph with the pulse:
+            create_output_pulsegraphs(std::to_string(event->number),
+                                      std::to_string(pixel_index.x()) + "-" + std::to_string(pixel_index.y()),
+                                      "amp_pulse",
+                                      "Amplifier signal without noise",
+                                      timestep,
+                                      amplified_pulse_vec);
+        }
+
+        // Apply noise to the amplified pulse
+        allpix::normal_distribution<double> pulse_smearing(0, sigmaNoise_);
+        LOG(TRACE) << "Adding electronics noise with sigma = " << Units::display(sigmaNoise_, {"mV", "V"});
+        std::transform(amplified_pulse_vec.begin(),
+                       amplified_pulse_vec.end(),
+                       amplified_pulse_vec.begin(),
+                       [&pulse_smearing, &event](auto& c) { return c + (pulse_smearing(event->getRandomEngine())); });
+
+        // Fill a graphs with the individual pixel pulses
+        if(output_pulsegraphs_) {
+            create_output_pulsegraphs(std::to_string(event->number),
+                                      std::to_string(pixel_index.x()) + "-" + std::to_string(pixel_index.y()),
+                                      "amp_pulse_noise",
+                                      "Amplifier signal with added noise",
+                                      timestep,
+                                      amplified_pulse_vec);
+        }
+
+        // Find threshold crossing - if any
+        auto ts1_result = model_->get_ts1(timestep, amplified_pulse_vec);
+        if(!std::get<0>(ts1_result)) {
+            LOG(DEBUG) << "Amplified signal never crossed threshold, continuing.";
+            continue;
+        }
+
+        auto ts1 = std::get<1>(ts1_result);
+
+        // Find second time stamp
+        auto ts2 = model_->get_ts2(ts1, timestep, amplified_pulse_vec, event->getRandomEngine());
+
+        LOG(DEBUG) << "Pixel " << pixel_index << ": TS1 " << std::to_string(ts1) + "clk"
+                   << ", TS2 " << std::to_string(ts2) + "clk";
+
+        // Fill histograms if requested
+        if(output_plots_) {
+            h_ts1->Fill(ts1);
+            h_ts2->Fill(ts2);
+            h_tot->Fill(ts2 * model_->get_ts2_clock() - ts1 * model_->get_ts1_clock());
+        }
+
+        // Add the hit to the hitmap
+        hits.emplace_back(pixel,
+                          static_cast<double>(ts1),
+                          pixel_charge.getGlobalTime() + ts1 * model_->get_ts1_clock(),
+                          static_cast<double>(ts2),
+                          &pixel_charge);
+    }
+
+    // Output summary and update statistics
+    LOG(INFO) << "Digitized " << hits.size() << " pixel hits";
+
+    if(!hits.empty()) {
+        // Create and dispatch hit message
+        auto hits_message = std::make_shared<PixelHitMessage>(std::move(hits), getDetector());
+        messenger_->dispatchMessage(this, hits_message, event);
+    }
+}
+
+void MuPixDigitizerModule::create_output_pulsegraphs(const std::string& s_event_num,
+                                                     const std::string& s_pixel_index,
+                                                     const std::string& s_name,
+                                                     const std::string& s_title,
+                                                     double timestep,
+                                                     const std::vector<double>& plot_pulse_vec) {
+
+    // Generate x-axis:
+    std::vector<double> amptime(plot_pulse_vec.size());
+    // clang-format off
+    std::generate(amptime.begin(), amptime.end(), [n = 0.0, timestep]() mutable {  auto now = n; n += timestep; return now; });
+    // clang-format on
+
+    // scale the y-axis values to be in mV instead of MV
+    std::vector<double> pulse_in_mV(plot_pulse_vec.size());
+    std::transform(
+        plot_pulse_vec.begin(), plot_pulse_vec.end(), pulse_in_mV.begin(), [](auto& c) { return Units::convert(c, "mV"); });
+
+    std::string name = s_name + "_ev" + s_event_num + "_px" + s_pixel_index;
+    auto* csa_pulse_graph = new TGraph(static_cast<int>(pulse_in_mV.size()), &amptime[0], &pulse_in_mV[0]);
+    csa_pulse_graph->GetXaxis()->SetTitle("t [ns]");
+    csa_pulse_graph->GetYaxis()->SetTitle("CSA output [mV]");
+    csa_pulse_graph->SetTitle((s_title + " in pixel (" + s_pixel_index + ")").c_str());
+    getROOTDirectory()->WriteTObject(csa_pulse_graph, name.c_str());
+}
+
+void MuPixDigitizerModule::finalize() {
+    if(output_plots_) {
+        // Write histograms
+        LOG(TRACE) << "Writing output plots to file";
+        h_ts1->Write();
+        h_ts2->Write();
+        h_tot->Write();
+    }
+}

--- a/src/modules/MuPixDigitizer/MuPixDigitizerModule.hpp
+++ b/src/modules/MuPixDigitizer/MuPixDigitizerModule.hpp
@@ -1,0 +1,92 @@
+/**
+ * @file
+ * @brief Definition of MuPix digitization module
+ * @copyright Copyright (c) 2021 CERN and the Allpix Squared authors.
+ * This software is distributed under the terms of the MIT License, copied verbatim in the file "LICENSE.md".
+ * In applying this license, CERN does not waive the privileges and immunities granted to it by virtue of its status as an
+ * Intergovernmental Organization or submit itself to any jurisdiction.
+ */
+
+#ifndef ALLPIX_MUPIX_DIGITIZER_MODULE_H
+#define ALLPIX_MUPIX_DIGITIZER_MODULE_H
+
+#include <memory>
+#include <random>
+#include <string>
+
+#include "core/config/Configuration.hpp"
+#include "core/messenger/Messenger.hpp"
+#include "core/module/Module.hpp"
+#include "core/utils/prng.h"
+
+#include "objects/PixelCharge.hpp"
+
+#include "MuPixModel.hpp"
+
+#include <TF1.h>
+#include <TH1D.h>
+#include <TH1F.h>
+
+namespace allpix {
+    /**
+     * @ingroup Modules
+     * @brief Module to simulate MuPix digitization of collected charges
+     * @note This module supports parallelization
+     *
+     * This module provides a relatively simple simulation of a charge-sensitive amplifier
+     * that works similar to MuPix type detectors. Compared to the CSADigitizer module,
+     * amplification and threshold calculation work differently.
+     */
+    class MuPixDigitizerModule : public Module {
+    public:
+        /**
+         * @brief Constructor for this detector-specific module
+         * @param config Configuration object for this module as retrieved from the steering file
+         * @param messenger Pointer to the messenger object to allow binding to messages on the bus
+         * @param detector Pointer to the detector for this module instance
+         */
+        MuPixDigitizerModule(Configuration& config, Messenger* messenger, std::shared_ptr<Detector> detector);
+
+        /**
+         * @brief Initialize optional ROOT histograms
+         */
+        void initialize() override;
+
+        /**
+         * @brief Simulate digitization process
+         */
+        void run(Event* event) override;
+
+        /**
+         * @brief Finalize and write optional histograms
+         */
+        void finalize() override;
+
+    private:
+        // Control of module output settings
+        bool output_plots_{}, output_pulsegraphs_{};
+        Messenger* messenger_;
+
+        // Chip implementation
+        std::unique_ptr<mupix::MuPixModel> model_;
+
+        // Noise parameter
+        double sigmaNoise_{};
+
+        // Output histograms
+        Histogram<TH1D> h_ts1{}, h_ts2{};
+        Histogram<TH1F> h_tot{};
+
+        /**
+         * @brief Create output plots of the pulses
+         */
+        void create_output_pulsegraphs(const std::string& s_event_num,
+                                       const std::string& s_pixel_index,
+                                       const std::string& s_name,
+                                       const std::string& s_title,
+                                       double timestep,
+                                       const std::vector<double>& plot_pulse_vec);
+    };
+} // namespace allpix
+
+#endif /* ALLPIX_MUPIX_DIGITIZER_MODULE_H */

--- a/src/modules/MuPixDigitizer/MuPixModel.cpp
+++ b/src/modules/MuPixDigitizer/MuPixModel.cpp
@@ -1,0 +1,101 @@
+/**
+ * @file
+ * @brief Implementation of the common MuPixModel class
+ * @copyright Copyright (c) 2021 CERN and the Allpix Squared authors.
+ * This software is distributed under the terms of the MIT License, copied verbatim in the file "LICENSE.md".
+ * In applying this license, CERN does not waive the privileges and immunities granted to it by virtue of its status as an
+ * Intergovernmental Organization or submit itself to any jurisdiction.
+ */
+
+#include "MuPixModel.hpp"
+
+#include <numeric>
+
+#include "core/messenger/Messenger.hpp"
+#include "core/utils/distributions.h"
+
+using namespace allpix::mupix;
+
+MuPixModel::MuPixModel(Configuration& config) {
+    // Set default values
+    config.setDefault<double>("threshold", Units::get(35, "mV"));
+    config.setDefault<double>("clock_bin_ts1", Units::get(8, "ns"));
+    config.setDefault<double>("clock_bin_ts2", Units::get(128, "ns"));
+    config.setDefault<double>("integration_time", Units::get(5, "us"));
+    config.setDefault<double>("tot_cap", Units::get(3500, "ns"));
+    config.setDefault<double>("tot_cap_deviation", Units::get(150, "ns"));
+
+    // Get config value
+    threshold_ = config.get<double>("threshold");
+    ts1_clock_ = config.get<double>("clock_bin_ts1");
+    ts2_clock_ = config.get<double>("clock_bin_ts2");
+    integration_time_ = config.get<double>("integration_time");
+    tot_cap_ = config.get<double>("tot_cap");
+    tot_cap_deviation_ = config.get<double>("tot_cap_deviation");
+}
+
+std::vector<double> MuPixModel::amplify_pulse(const Pulse&) const {
+    LOG(ERROR) << "Reference amplification called";
+    return std::vector<double>(1, 0.0);
+}
+
+std::tuple<bool, unsigned int> MuPixModel::get_ts1(double timestep, const std::vector<double>& pulse) const {
+    LOG(TRACE) << "Calculating TS1";
+    bool threshold_crossed = false;
+    unsigned int ts1_clock_cycles = 0;
+
+    // Lambda for threshold calculation
+    auto calculate_is_above_threshold = [=](double bin) { return (threshold_ > 0. ? bin > threshold_ : bin < threshold_); };
+
+    // Find the point where the signal crosses the threshold
+    auto max_ts1_clock_cycles = static_cast<unsigned int>(std::ceil(integration_time_ / ts1_clock_));
+    while(ts1_clock_cycles < max_ts1_clock_cycles) {
+        auto bin = pulse.at(static_cast<size_t>(std::floor(ts1_clock_cycles * ts1_clock_ / timestep)));
+        if(calculate_is_above_threshold(bin)) {
+            threshold_crossed = true;
+            break;
+        };
+        ts1_clock_cycles++;
+    }
+    return {threshold_crossed, ts1_clock_cycles};
+}
+
+unsigned int MuPixModel::get_ts2(unsigned int ts1,
+                                 double timestep,
+                                 const std::vector<double>& pulse,
+                                 allpix::RandomNumberGenerator& rng) const {
+    LOG(TRACE) << "Calculating TS2";
+    bool was_above_treshold = true;
+    auto ts2_clock_cycles = static_cast<unsigned int>(std::ceil(ts1 * ts1_clock_ / ts2_clock_));
+    auto final_ts2_clock_cycles = ts2_clock_cycles;
+
+    // Lambda for threshold calculation
+    auto calculate_is_below_threshold = [=](double bin) { return (threshold_ > 0 ? bin < threshold_ : bin > threshold_); };
+
+    // ToT cap smearing
+    allpix::normal_distribution<double> tot_cap_smearing(tot_cap_, tot_cap_deviation_);
+    auto tot_cap = tot_cap_smearing(rng);
+
+    // Calculate max TS2 clock cycles after next TS1 cycle, or cap at integration time
+    auto max_ts2_time = std::min<double>(ts1 * ts1_clock_ + tot_cap, integration_time_);
+    auto max_ts2_clock_cycles = static_cast<unsigned int>(std::ceil(max_ts2_time / ts2_clock_));
+
+    while(ts2_clock_cycles < max_ts2_clock_cycles) {
+        auto bin = pulse.at(static_cast<size_t>(std::floor(ts2_clock_cycles * ts2_clock_ / timestep)));
+        auto is_below_threshold = calculate_is_below_threshold(bin);
+        if(was_above_treshold && is_below_threshold) {
+            final_ts2_clock_cycles = ts2_clock_cycles;
+            was_above_treshold = false;
+        } else if(!was_above_treshold && !is_below_threshold) {
+            was_above_treshold = true;
+        }
+        ts2_clock_cycles++;
+    }
+
+    // Cap TS2 if pulse is above threshold at the end
+    if(was_above_treshold) {
+        final_ts2_clock_cycles = max_ts2_clock_cycles - 1;
+    }
+
+    return final_ts2_clock_cycles;
+}

--- a/src/modules/MuPixDigitizer/MuPixModel.hpp
+++ b/src/modules/MuPixDigitizer/MuPixModel.hpp
@@ -1,0 +1,102 @@
+/**
+ * @file
+ * @brief Definition of the common MuPixModel class
+ * @copyright Copyright (c) 2021 CERN and the Allpix Squared authors.
+ * This software is distributed under the terms of the MIT License, copied verbatim in the file "LICENSE.md".
+ * In applying this license, CERN does not waive the privileges and immunities granted to it by virtue of its status as an
+ * Intergovernmental Organization or submit itself to any jurisdiction.
+ */
+
+#ifndef ALLPIX_MUPIX_CHIP_H
+#define ALLPIX_MUPIX_CHIP_H
+
+#include <tuple>
+#include <vector>
+
+#include "core/config/Configuration.hpp"
+#include "core/utils/distributions.h"
+#include "core/utils/prng.h"
+
+#include "objects/Pulse.hpp"
+
+namespace allpix {
+    namespace mupix {
+        /**
+         * @brief Reference Implementation for MuPix type digitization
+         *
+         * This class provides three main reference functions: amplification,
+         * TS1 and TS2 calculation. It also provides a virtual impulse response
+         * function that needs to implemented if one wants to use the reference
+         * amplification code.
+         */
+        class MuPixModel {
+        public:
+            /**
+             * @brief Constructor for this base mupix model
+             * @param config Configuration object as retrieved from the module
+             */
+            MuPixModel(Configuration& config);
+
+            /**
+             * @brief Destructor for this class
+             */
+            virtual ~MuPixModel() = default;
+
+            /**
+             * @brief Amplifies charge pulse
+             * @param pulse Pulse object
+             * @return Amplified pulse vector
+             */
+            virtual std::vector<double> amplify_pulse(const Pulse& pulse) const;
+
+            /**
+             * @brief Calculate time of first threshold crossing (TS1)
+             * @param timestep Step size of the input pulse
+             * @param pulse    Pulse after amplification and electronics noise
+             * @return Tuple containing information if crossed  and TS1 cycles of crossing
+             */
+            virtual std::tuple<bool, unsigned int> get_ts1(double timestep, const std::vector<double>& pulse) const;
+
+            /**
+             * @brief Calculate time of last threshold crossing from above to below (TS2)
+             * @param ts1      TS1 clock cycles of arrival
+             * @param timestep Step size of the input pulse
+             * @param pulse    Pulse after amplification and electronics noise
+             * @param rng      Random Number Generator of the event
+             * @return TS2 cycles of crossing
+             */
+            virtual unsigned int
+            get_ts2(unsigned int ts1, double timestep, const std::vector<double>& pulse, RandomNumberGenerator& rng) const;
+
+            /**
+             * @brief Returns the TS1 clock bin size
+             * @return TS1 clock bin size
+             */
+            double get_ts1_clock() const { return ts1_clock_; };
+
+            /**
+             * @brief Returns the TS2 clock bin size
+             * @return TS2 clock bin size
+             */
+            double get_ts2_clock() const { return ts2_clock_; };
+
+            /**
+             * @brief Returns the pulse integration time
+             * @return integration time
+             */
+            double get_integration_time() const { return integration_time_; };
+
+        protected:
+            // Parameters for the threshold logic
+            double threshold_{}, ts1_clock_{}, ts2_clock_{};
+
+            // ToT cap
+            double tot_cap_{}, tot_cap_deviation_{};
+
+            // Pulse calculation times
+            double integration_time_{};
+        };
+    } // namespace mupix
+} // namespace allpix
+
+#endif /* ALLPIX_MUPIX_CHIP_H */

--- a/src/modules/MuPixDigitizer/README.md
+++ b/src/modules/MuPixDigitizer/README.md
@@ -1,0 +1,71 @@
+# MuPixDigitizer
+**Maintainer**: Stephan Lachnit (<stephanlachnit@debian.org>)
+**Status**: Beta
+**Input**: PixelCharge
+**Output**: PixelHit
+
+### Description
+Digitizer for MuPix-Type digitizers. These are charge sensitive digitizers, so this module is similar to the CSADigitizer module. However, there are some key differences to the CSADigitizer.
+
+This module always operates with threshold logic in clock cycles. Instead of returning the ToT like the CSADigitzier module, this module returns the clock cycles of the first threshold crossing (TS1) and the last threshold crossing (TS2). These correspond to `local_time` and `signal` in the `PixelHit` class.
+
+Similar to the CSADigitizer module, this module amplifies the pulse for the `integration_time`. In the reference implementation, TS2 is determined by taking the last threshold crossing from above the threshold to below the threshold within `tot_cap`. This second time starts in the first TS2 clock cycle after TS1 was set. If TS1 is so late the second integration time would exceed the integration time, it is limited to match the integration time.
+
+With the `fast_amplification` parameter a faster but less precise amplification method can be chosen. In the fast mode, the pulse shape is ignored, which reduces time precision. This has more impact on the ToA than it has on the ToT (in case of the MuPix10).
+Noise can be applied with the `sigma_noise` parameter similar to the CSADigitizer module.
+
+Currently, only the MuPix10 is implented in three modes: the normal single threshold mode, a mode with a second threshold, and a mode with a rising threshold. The amplification curve can be approximated with $`Amp(t,Q) = Q \cdot A (1 - \exp{-\frac{t}{R}} - F \cdot t`$.
+
+The first mode operates similar to the CSADigitzer module. The second mode adds a second, higher threshold that when crossed sets the hit flag. If the second threshold is not crossed, not hit will be registerd. TS1 and TS2 are still set by the first threshold. The ramp mode adds linear rising threshold that gets activated when the pulse hits the first threshold. TS2 is set when the amplified pulse hits this rising threshold.
+
+The module can be easily extend with different model by deriving a class from the `MuPixModel` class, which acts a reference class. Amplification, TS1 and TS2 calculation can be adjusted freely.
+
+### Parameters
+* `model` : Choice between different Chips. Currently implemented are `mupix10`, `mupix10double` and `mupix10ramp`.
+* `fast_amplification` : Whether to amplify the pulse fast or precise. Defaults to false.
+* `sigma_noise` : Standard deviation of the Gaussian-distributed noise added to the output signal. Defaults to 1 mV.
+* `threshold` : Threshold for considering the output signal as a hit. Defaults to 30 mV.
+* `clock_bin_ts1` : Duration of a clock cycle for the TS1 clock. Defaults to 8 ns.
+* `clock_bin_ts2` : Duration of a clock cycle for the TS2 clock. Defaults to 128 ns.
+* `integration_time` : Duration for which the charge pulse is amplified. Defaults to 2 us.
+* `tot_cap` : Duration in which to look for the last treshold crossing. Defaults to 2 us.
+
+#### Parameters for the MuPix10 (`mupix10`)
+* `parameters` : Array containing the impulse response parameters (A, R, F).
+
+#### Parameters for the MuPix10 with second threshold (`mupix10double`)
+* `parameters` : Same as for the `mupix10` model.
+* `threshold_high` : Second threshold, which when crossed sets the hit flag. Defaults to 40 mV.
+
+#### Parameters for the MuPix10 in ramp mode (`mupix10ramp`)
+* `parameters` : Same as for the `mupix10` model.
+* `threshold_slew_rate` : Slew rate of the second threshold.
+
+### Plotting parameters
+* `output_plots` : Enables simple output histograms to be be generated from the data in every step (slows down simulation considerably). Disabled by default.
+* `output_pulsegraphs`: Determines if pulse graphs should be generated for every event. This creates several graphs per event, depending on how many pixels see a signal, and can slow down the simulation. It is not recommended to enable this option for runs with more than a couple of events. Disabled by default.
+
+### Usage
+Example for the MuPix10 with a single threshold
+```ini
+[MuPixDigitizer]
+model = "mupix10"
+fast_amplification = true
+sigma_noise = 1mV
+treshold = 40mV
+clock_bin_ts1 = 8ns
+clock_bin_ts2 = 128ns
+parameters = 2.51424577e+14V/C 3.35573247e-07V/C/s 1.85969061e+04V/s
+```
+Example for the MuPix10 with a second threshold
+```ini
+[MuPixDigitizer]
+model = "mupix10double"
+threshold_high = 40mV
+```
+Example for the MuPix10 in ramp mode
+```ini
+[MuPixDigitizer]
+model = "mupix10double"
+threshold_slew_rate = 1mV/ns
+```


### PR DESCRIPTION
New module that allows a bit more flexible digitization than the CSADigitizer. Most code is coppied from there.

tl;dr: this module easily allows to implement different kinds of digitzers. This is done by creating a base class `MuPixChip`, with reference implementations for Amplification, TS1 and TS2. From there, it's easy to create a subclass that changes only the functions where it deviates from the reference design.

Note that at this stage I didn't even test it, it only shows the OO structures I intend to use. There some things I still need to figure (e.g. the split of config values between MuPixDigitizerModule and MuPixChip. It also requires a lot of polish.