### PR TITLE
Add instant decay option to custom ions

### DIFF
--- a/src/modules/DepositionGeant4/GeneratorActionG4.cpp
+++ b/src/modules/DepositionGeant4/GeneratorActionG4.cpp
@@ -270,6 +270,14 @@ void GeneratorActionG4::GeneratePrimaries(G4Event* event) {
                     particle->SetPDGLifeTime(0.);
                 }
                 single_source->SetParticleCharge(allpix::from_string<int>(ion[3]));
+            } else if(std::regex_match(
+                          particle_type_, ion, std::regex("ion/([0-9]+)/([0-9]+)/([-+]?[0-9]+)/([0-9.]+(?:[a-zA-Z]+)?)")) &&
+                      ion.ready()) {
+                // Parse old declaration with /Z/A/Q/E
+                particle = G4IonTable::GetIonTable()->GetIon(
+                    allpix::from_string<int>(ion[1]), allpix::from_string<int>(ion[2]), allpix::from_string<double>(ion[4]));
+                single_source->SetParticleCharge(allpix::from_string<int>(ion[3]));
+                LOG(WARNING) << "Using \"ion/Z/A/Q/E\" is deprecated and superseded by \"ion/Z/A/Q/E/D\".";
             } else {
                 throw InvalidValueError(config_, "particle_type", "cannot parse parameters for ion.");
             }

--- a/src/modules/DepositionGeant4/GeneratorActionG4.cpp
+++ b/src/modules/DepositionGeant4/GeneratorActionG4.cpp
@@ -258,13 +258,17 @@ void GeneratorActionG4::GeneratePrimaries(G4Event* event) {
                     << "A radioactive isotope is used as particle source, but the source energy is not set to zero.";
             }
         } else if(particle_type_.substr(0, 3) == "ion") {
-            // Parse particle type as ion with components /Z/A/Q/E
+            // Parse particle type as ion with components /Z/A/Q/E/D
             std::smatch ion;
-            if(std::regex_match(
-                   particle_type_, ion, std::regex("ion/([0-9]+)/([0-9]+)/([-+]?[0-9]+)/([0-9.]+(?:[a-zA-Z]+)?)")) &&
+            if(std::regex_match(particle_type_,
+                                ion,
+                                std::regex("ion/([0-9]+)/([0-9]+)/([-+]?[0-9]+)/([0-9.]+(?:[a-zA-Z]+)?)/(true|false)")) &&
                ion.ready()) {
                 particle = G4IonTable::GetIonTable()->GetIon(
                     allpix::from_string<int>(ion[1]), allpix::from_string<int>(ion[2]), allpix::from_string<double>(ion[4]));
+                if(allpix::from_string<bool>(ion[5])) {
+                    particle->SetPDGLifeTime(0.);
+                }
                 single_source->SetParticleCharge(allpix::from_string<int>(ion[3]));
             } else {
                 throw InvalidValueError(config_, "particle_type", "cannot parse parameters for ion.");

--- a/src/modules/DepositionGeant4/GeneratorActionG4.cpp
+++ b/src/modules/DepositionGeant4/GeneratorActionG4.cpp
@@ -279,6 +279,9 @@ void GeneratorActionG4::GeneratePrimaries(G4Event* event) {
 
         // mark the initialization done
         initialize_ion_as_particle_ = false;
+
+        LOG(DEBUG) << "Using ion " << particle->GetParticleName() << " (ID " << particle->GetPDGEncoding() << ") with "
+                   << Units::display(particle->GetPDGLifeTime(), {"s", "ns"}) << " lifetime.";
     }
 
     particle_source_->GeneratePrimaryVertex(event);

--- a/src/modules/DepositionGeant4/README.md
+++ b/src/modules/DepositionGeant4/README.md
@@ -34,13 +34,13 @@ Radioactive isotopes are forced to decay immediately in order to allow sensible 
 Currently, the following radioactive isotopes are supported: `Fe55`, `Am241`, `Sr90`, `Co60`, `Cs137`.
 Note that for `Cs137` the `cutoff_time` has to be set to 221 seconds for the decay to work properly.
 
-Ions can be used as particles by setting their atomic properties, i.e. the atomic number Z, the atomic mass A, their charge Q and the excitation energy E via the following syntax:
+Ions can be used as particles by setting their atomic properties, i.e. the atomic number Z, the atomic mass A, their charge Q, the excitation energy E and whether or not they should decay instantly via the following syntax:
 
 ```ini
-particle_type = "ion/Z/A/Q/E"
+particle_type = "ion/Z/A/Q/E/D"
 ```
 
-where `Z` and `A` are unsigned integers, `Q` is a signed integer and `E` a floating point value with units, e.g. `13eV`.
+where `Z` and `A` are unsigned integers, `Q` is a signed integer, `E` a floating point value with units, e.g. `13eV`, and `D` is `true` for instant decay or `false` else.
 
 #### Energy Deposition and Charge Carrier creation
 
@@ -132,7 +132,7 @@ A Xenon-132 ion beam could be simulated using the following configuration:
 ```ini
 [DepositionGeant4]
 physics_list = FTFP_BERT_LIV
-particle_type = "ion/54/132/0/0eV"
+particle_type = "ion/54/132/0/0eV/false"
 source_energy = 10MeV
 source_position = 0 0 -1mm
 source_type = "beam"

--- a/src/modules/DepositionGeant4/tests/09-ions.conf
+++ b/src/modules/DepositionGeant4/tests/09-ions.conf
@@ -1,0 +1,24 @@
+[Allpix]
+detectors_file = "detector.conf"
+number_of_events = 1
+random_seed = 4
+
+[GeometryBuilderGeant4]
+
+[DepositionGeant4]
+log_level = DEBUG
+particle_type = "ion/39/90/0/0/true"
+source_energy = 0eV
+source_position = 0um 0um -1mm
+source_type = "point"
+
+[ElectricFieldReader]
+model = "linear"
+bias_voltage = 100V
+depletion_voltage = 150V
+
+[ProjectionPropagation]
+temperature = 293K
+propagate_holes = true
+
+#PASS Using ion Y90 (ID 1000390900) with 0s lifetime.


### PR DESCRIPTION
Closes #37.

I also added an output with infos about the ion as this isn't done before because ions need to be initialized later. The lifetime will be `-1ns` for stable ions, I didn't bother to format it to say this explicitly as this is a debug only output anyway.

The output also allows to add a test, checking if the lifetime is set correctly.