### PR TITLE
CSADigitizerModule: Use capture-by-copy in threshold lambdas

### DIFF
--- a/.github/workflows/compilation-and-test.yml
+++ b/.github/workflows/compilation-and-test.yml
@@ -1,4 +1,4 @@
-name: github-ci
+name: compile&test
 on:
   pull_request:
     types: [opened, reopened, edited, ready_for_review, synchronize]
@@ -110,20 +110,3 @@ jobs:
           chmod a+x bin/allpix
           cd build
           ctest -R ${{matrix.whichtest}} --output-on-failure -j4
-
-  format:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
-    - uses: aidasoft/run-lcg-view@v2
-      with:
-        run_local_checkout: 'false'
-        release-platform: "${{env.LCG_VERSION}}/x86_64-centos7-clang10-opt"
-        run: |
-          mkdir build
-          cd build
-          cmake -GNinja -DCMAKE_CXX_FLAGS="-Werror" -DBUILD_LCIOWriter=ON -DCMAKE_BUILD_TYPE=RELEASE -DLCIO_DIR=$LCIO_DIR ..
-          ninja check-format

--- a/.github/workflows/format-and-lint.yml
+++ b/.github/workflows/format-and-lint.yml
@@ -1,0 +1,60 @@
+name: format&lint
+on:
+  pull_request:
+    types: [opened, reopened, edited, ready_for_review, synchronize]
+env:
+  LCG_VERSION: LCG_99
+jobs:
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: aidasoft/run-lcg-view@v2
+      with:
+        run_local_checkout: 'false'
+        release-platform: "${{env.LCG_VERSION}}/x86_64-centos7-clang10-opt"
+        run: |
+          mkdir build
+          cd build
+          cmake -GNinja -DCMAKE_CXX_FLAGS="-Werror" -DBUILD_LCIOWriter=ON -DCMAKE_BUILD_TYPE=RELEASE -DLCIO_DIR=$LCIO_DIR ..
+          ninja check-format
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: aidasoft/run-lcg-view@v2
+      with:
+        run_local_checkout: 'false'
+        release-platform: "${{env.LCG_VERSION}}/x86_64-centos7-clang10-opt"
+        run: |
+          mkdir build
+          cd build
+          cmake -GNinja -DCMAKE_CXX_FLAGS="-Werror" -DBUILD_LCIOWriter=ON -DCMAKE_BUILD_TYPE=RELEASE -DLCIO_DIR=$LCIO_DIR ..
+          ninja check-lint
+
+  cmake-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: aidasoft/run-lcg-view@v2
+      with:
+        run_local_checkout: 'false'
+        release-platform: "${{env.LCG_VERSION}}/x86_64-centos7-clang10-opt"
+        run: |
+          mkdir build
+          cd build
+          export PATH=$PATH:~/.local/bin
+          pip install --trusted-host=pypi.org --user cmakelang
+          cmake -GNinja ..
+          ninja lint-cmake

--- a/src/modules/CSADigitizer/CSADigitizerModule.cpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.cpp
@@ -350,18 +350,18 @@ std::tuple<bool, unsigned int, double> CSADigitizerModule::get_toa(double timest
     double arrival_time = 0;
 
     // Lambda for threshold calculation:
-    auto is_above_threshold = [](double bin, double threshold, bool ignore_polarity) {
-        if(ignore_polarity) {
-            return (std::fabs(bin) > std::fabs(threshold));
+    auto is_above_threshold = [=](double bin) {
+        if(ignore_polarity_) {
+            return (std::fabs(bin) > std::fabs(threshold_));
         } else {
-            return (threshold > 0 ? bin > threshold : bin < threshold);
+            return (threshold_ > 0 ? bin > threshold_ : bin < threshold_);
         }
     };
 
     // Find the point where the signal crosses the threshold, latch ToA
     while(arrival_time < integration_time_) {
         auto bin = pulse.at(static_cast<size_t>(std::floor(arrival_time / timestep)));
-        if(is_above_threshold(bin, threshold_, ignore_polarity_)) {
+        if(is_above_threshold(bin)) {
             threshold_crossed = true;
             break;
         };
@@ -377,11 +377,11 @@ unsigned int CSADigitizerModule::get_tot(double timestep, double arrival_time, c
     unsigned int tot_clock_cycles = 0;
 
     // Lambda for threshold calculation:
-    auto is_below_threshold = [](double bin, double threshold, bool ignore_polarity) {
-        if(ignore_polarity) {
-            return (std::fabs(bin) < std::fabs(threshold));
+    auto is_below_threshold = [=](double bin) {
+        if(ignore_polarity_) {
+            return (std::fabs(bin) < std::fabs(threshold_));
         } else {
-            return (threshold > 0 ? bin < threshold : bin > threshold);
+            return (threshold_ > 0 ? bin < threshold_ : bin > threshold_);
         }
     };
 
@@ -389,7 +389,7 @@ unsigned int CSADigitizerModule::get_tot(double timestep, double arrival_time, c
     auto tot_time = clockToT_ * std::ceil(arrival_time / clockToT_);
     while(tot_time < integration_time_) {
         auto bin = pulse.at(static_cast<size_t>(std::floor(tot_time / timestep)));
-        if(is_below_threshold(bin, threshold_, ignore_polarity_)) {
+        if(is_below_threshold(bin)) {
             break;
         }
         tot_clock_cycles++;

--- a/src/modules/DepositionGeant4/DepositionGeant4Module.cpp
+++ b/src/modules/DepositionGeant4/DepositionGeant4Module.cpp
@@ -391,9 +391,12 @@ void DepositionGeant4Module::construct_sensitive_detectors_and_fields(double fan
         }
         useful_deposition = true;
 
+        // Get the hit transformation matrix
+        auto* hit_transform = calculate_hit_transform(detector->getModel());
+
         // Get model of the sensitive device
         auto* sensitive_detector_action = new SensitiveDetectorActionG4(
-            detector, track_info_manager_.get(), charge_creation_energy, fano_factor, cutoff_time);
+            detector, track_info_manager_.get(), hit_transform, charge_creation_energy, fano_factor, cutoff_time);
         auto logical_volume = geo_manager_->getExternalObject<G4LogicalVolume>(detector->getName(), "sensor_log");
         if(logical_volume == nullptr) {
             throw ModuleError("Detector " + detector->getName() + " has no sensitive device (broken Geant4 geometry)");
@@ -443,4 +446,8 @@ void DepositionGeant4Module::record_module_statistics() {
     for(auto& sensor : sensors_) {
         total_charges_ += sensor->getTotalDepositedCharge();
     }
+}
+
+G4RotationMatrix* DepositionGeant4Module::calculate_hit_transform(const std::shared_ptr<DetectorModel>&) {
+    return new G4RotationMatrix();
 }

--- a/src/modules/DepositionGeant4/DepositionGeant4Module.hpp
+++ b/src/modules/DepositionGeant4/DepositionGeant4Module.hpp
@@ -92,6 +92,16 @@ namespace allpix {
          */
         void record_module_statistics();
 
+        /**
+         * @brief Calculate hit transformation matrix for a given detector model
+         * @param model Detector model
+         * @returns Hit transformation matrix pointer
+         *
+         * @note This matrix transforms the Geant4 local coordinate system of the sensor
+         * volume to the APSQ local coordinate system based on the detector model type.
+         */
+        G4RotationMatrix* calculate_hit_transform(const std::shared_ptr<DetectorModel>& model);
+
         Messenger* messenger_;
         GeometryManager* geo_manager_;
 

--- a/src/modules/DepositionGeant4/SensitiveDetectorActionG4.cpp
+++ b/src/modules/DepositionGeant4/SensitiveDetectorActionG4.cpp
@@ -36,6 +36,7 @@ using namespace allpix;
 
 SensitiveDetectorActionG4::SensitiveDetectorActionG4(const std::shared_ptr<Detector>& detector,
                                                      TrackInfoManager* track_info_manager,
+                                                     const G4RotationMatrix* hit_transform,
                                                      double charge_creation_energy,
                                                      double fano_factor,
                                                      double cutoff_time)
@@ -46,6 +47,8 @@ SensitiveDetectorActionG4::SensitiveDetectorActionG4(const std::shared_ptr<Detec
     // Add the sensor to the internal sensitive detector manager
     G4SDManager* sd_man_g4 = G4SDManager::GetSDMpointer();
     sd_man_g4->AddNewDetector(this);
+
+    hit_transform_ = hit_transform;
 }
 
 G4bool SensitiveDetectorActionG4::ProcessHits(G4Step* step, G4TouchableHistory*) {
@@ -73,6 +76,9 @@ G4bool SensitiveDetectorActionG4::ProcessHits(G4Step* step, G4TouchableHistory*)
     // Calculate the charge deposit at a local position
     auto deposit_position = detector_->getLocalPosition(static_cast<ROOT::Math::XYZPoint>(step_pos));
     auto deposit_position_g4 = theTouchable->GetHistory()->GetTopTransform().TransformPoint(step_pos);
+
+    // Transform the hit position using the rotation matrix
+    deposit_position_g4 *= *hit_transform_;
 
     // Calculate number of electron hole pairs produced, taking into account fluctuations between ionization and lattice
     // excitations via the Fano factor. We assume Gaussian statistics here.

--- a/src/modules/DepositionGeant4/SensitiveDetectorActionG4.hpp
+++ b/src/modules/DepositionGeant4/SensitiveDetectorActionG4.hpp
@@ -36,12 +36,14 @@ namespace allpix {
          * @brief Constructs the action handling for every sensitive detector
          * @param detector Detector this sensitive device is bound to
          * @param track_info_manager Pointer to the track information manager
+         * @param hit_transform Pointer to the hit transformation matrix
          * @param charge_creation_energy Energy needed per deposited charge
          * @param fano_factor Fano factor for fluctuations in the energy fraction going into e/h pair creation
          * @param cutoff_time Cut-off time for the creation of secondary particles
          */
         SensitiveDetectorActionG4(const std::shared_ptr<Detector>& detector,
                                   TrackInfoManager* track_info_manager,
+                                  const G4RotationMatrix* hit_transform,
                                   double charge_creation_energy,
                                   double fano_factor,
                                   double cutoff_time);
@@ -124,6 +126,8 @@ namespace allpix {
         std::vector<int> deposit_to_id_;
         // Map from track id to mc particle index
         std::map<int, size_t> id_to_particle_;
+
+        const G4RotationMatrix* hit_transform_;
     };
 } // namespace allpix
 


### PR DESCRIPTION
Just a quick thought I had while rewriting some code in the mupix digitizer. Capturing the `threshold` and `ignore_polarity` config values in these Lambdas makes the code more readable below, and since they don't change we can capture them by value.
 
If I understand it right, this might improve the performance by a tiny amount while also increasing memory usage by a tiny amount, as the captures will be stored within the lambda, but we call the lambda with less parameters. But it probably doesn't make a measurable difference and who knows what the compiler does.

PS: the commit diff is because github master is behind gitlab master