### PR TITLE
Fix type conversion for deposits causing peak shifts

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@ The following authors, in alphabetical order, have developed or contributed to A
 * Mathieu Benoit, BNL, [mbenoit](https://gitlab.cern.ch/mbenoit)
 * Thomas Billoud, Université de Montréal, [tbilloud](https://gitlab.cern.ch/tbilloud)
 * Tobias Bisanz, CERN, [tbisanz](https://gitlab.cern.ch/tbisanz)
+* Sebbe Blokhuizen, Stockholm University, Sioux Technologies, [SBlokhuizen](https://github.com/SBlokhuizen)
 * Marco Bomben, Université de Paris, [mbomben](https://gitlab.cern.ch/mbomben)
 * Koen van den Brandt, Nikhef, [kvandenb](https://gitlab.cern.ch/kvandenb)
 * Carsten Daniel Burgard, DESY, [cburgard](https://gitlab.cern.ch/cburgard)

--- a/src/modules/DepositionGeant4/SensitiveDetectorActionG4.cpp
+++ b/src/modules/DepositionGeant4/SensitiveDetectorActionG4.cpp
@@ -80,7 +80,7 @@ G4bool SensitiveDetectorActionG4::ProcessHits(G4Step* step, G4TouchableHistory*)
     // excitations via the Fano factor. We assume Gaussian statistics here.
     auto mean_charge = edep / charge_creation_energy_;
     allpix::normal_distribution<double> charge_fluctuation(mean_charge, std::sqrt(mean_charge * fano_factor_));
-    auto charge = static_cast<unsigned int>(std::max(charge_fluctuation(random_generator_), 0.));
+    auto charge = static_cast<unsigned int>(std::max(charge_fluctuation(random_generator_), 0.) + 0.5);
 
     const auto* userTrackInfo = dynamic_cast<TrackInfoG4*>(track->GetUserInformation());
     if(userTrackInfo == nullptr) {


### PR DESCRIPTION
Type conversion for number of charges creation during deposition truncated the result, causing bias to lower energies. This resulted in a peak shift towards lower energies. To fix this, the number of charges created is instead rounded to the nearest integer. Further details are explained here: https://allpix-squared-forum.web.cern.ch/t/charge-creation-type-conversion-introduces-peak-shift-to-lower-energies/405