### PR TITLE
GDMLOutputWriter: Error when exporting & importing GDML files 

### DIFF
--- a/src/modules/GDMLOutputWriter/GDMLOutputWriterModule.cpp
+++ b/src/modules/GDMLOutputWriter/GDMLOutputWriterModule.cpp
@@ -50,9 +50,8 @@ void GDMLOutputWriterModule::initialize() {
 
     G4GDMLParser parser;
     parser.SetRegionExport(true);
-    parser.Write(GDML_output_file,
-                 G4TransportationManager::GetTransportationManager()
-                     ->GetNavigatorForTracking()
-                     ->GetWorldVolume()
-                     ->GetLogicalVolume());
+    parser.Write(
+        GDML_output_file,
+        G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume()->GetLogicalVolume(),
+        false);
 }


### PR DESCRIPTION
Exported GDML files stored reference addresses in name. When exporting a GDML file using GDMLOutputWriterModule and importing GDML back into allpix, the following error occurs:

 -------- EEEE ------- G4Exception-START -------- EEEE -------                                                                                                                                                   *** ExceptionHandler is not defined ***                                                                 
*** G4Exception : ReadError                                                                                   
issued by : G4GDMLReadStructure::GetVolume()                                                      
Referenced volume 'world_log' was not found!                                                            
*** Fatal Exception ***                                                                                 
-------- EEEE ------- G4Exception-END -------- EEEE -------
Referenced volume 'world_log' was not found! 

Solved by removing the addresses from the names during GDML export.