### PR TITLE
WIP: Meshed magnetic field

### DIFF
--- a/src/modules/DepositionGeant4/DepositionGeant4Module.cpp
+++ b/src/modules/DepositionGeant4/DepositionGeant4Module.cpp
@@ -607,7 +607,8 @@ void DepositionGeant4Module::record_module_statistics() {
 
 MagneticField::MagneticField(GeometryManager* geometry_manager) : geometry_manager_(geometry_manager) {};
 
-void MagneticField::GetFieldValue(const double Point[4], double* Bfield) const {
+// The Geant4 API expects a const double Point[4], not the std::array<> the linter suggests
+void MagneticField::GetFieldValue(const double Point[4], double* Bfield) const { // NOLINT
     G4cout << "Getting magnetic field from geometry manager" << G4endl;
     ROOT::Math::XYZVector bfield_vector =
         geometry_manager_->getMagneticField(ROOT::Math::XYZPoint(Point[0], Point[1], Point[2]));

--- a/src/modules/DepositionGeant4/DepositionGeant4Module.cpp
+++ b/src/modules/DepositionGeant4/DepositionGeant4Module.cpp
@@ -605,7 +605,7 @@ void DepositionGeant4Module::record_module_statistics() {
     }
 }
 
-MagneticField::MagneticField(GeometryManager* geometry_manager) { geometry_manager_ = geometry_manager; }
+MagneticField::MagneticField(GeometryManager* geometry_manager) : geometry_manager_(geometry_manager) {};
 
 void MagneticField::GetFieldValue(const double Point[4], double* Bfield) const {
     G4cout << "Getting magnetic field from geometry manager" << G4endl;

--- a/src/modules/DepositionGeant4/DepositionGeant4Module.cpp
+++ b/src/modules/DepositionGeant4/DepositionGeant4Module.cpp
@@ -468,10 +468,10 @@ void DepositionGeant4Module::finalizeThread() {
 
 void DepositionGeant4Module::construct_sensitive_detectors_and_fields() {
     if(geo_manager_->hasMagneticField()) {
-        G4MagneticField* magField = new MagFieldG4(geo_manager_);
+        G4MagneticField* magneticField = new MagneticField(geo_manager_);
         G4FieldManager* globalFieldMgr = G4TransportationManager::GetTransportationManager()->GetFieldManager();
-        globalFieldMgr->SetDetectorField(magField);
-        globalFieldMgr->CreateChordFinder(magField);
+        globalFieldMgr->SetDetectorField(magneticField);
+        globalFieldMgr->CreateChordFinder(magneticField);
     }
 
     // Loop through all detectors and set the sensitive detector action that handles the particle passage
@@ -605,13 +605,12 @@ void DepositionGeant4Module::record_module_statistics() {
     }
 }
 
-MagFieldG4::MagFieldG4(GeometryManager* gm) { gm_ = gm; }
+MagneticField::MagneticField(GeometryManager* geometry_manager) { geometry_manager_ = geometry_manager; }
 
-MagFieldG4::~MagFieldG4(){};
-
-void MagFieldG4::GetFieldValue(const double Point[4], double* Bfield) const {
-    G4cout << "Getting mag field from gm" << G4endl;
-    ROOT::Math::XYZVector bfield_vector = gm_->getMagneticField(ROOT::Math::XYZPoint(Point[0], Point[1], Point[2]));
+void MagneticField::GetFieldValue(const double Point[4], double* Bfield) const {
+    G4cout << "Getting magnetic field from geometry manager" << G4endl;
+    ROOT::Math::XYZVector bfield_vector =
+        geometry_manager_->getMagneticField(ROOT::Math::XYZPoint(Point[0], Point[1], Point[2]));
     G4cout << bfield_vector << G4endl;
     Bfield[0] = bfield_vector.x();
     Bfield[1] = bfield_vector.y();

--- a/src/modules/DepositionGeant4/DepositionGeant4Module.cpp
+++ b/src/modules/DepositionGeant4/DepositionGeant4Module.cpp
@@ -31,7 +31,6 @@
 
 #include "G4FieldManager.hh"
 #include "G4TransportationManager.hh"
-#include "G4UniformMagField.hh"
 
 #include "core/config/exceptions.h"
 #include "core/geometry/GeometryManager.hpp"
@@ -469,17 +468,10 @@ void DepositionGeant4Module::finalizeThread() {
 
 void DepositionGeant4Module::construct_sensitive_detectors_and_fields() {
     if(geo_manager_->hasMagneticField()) {
-        MagneticFieldType magnetic_field_type_ = geo_manager_->getMagneticFieldType();
-
-        if(magnetic_field_type_ == MagneticFieldType::CONSTANT) {
-            ROOT::Math::XYZVector b_field = geo_manager_->getMagneticField(ROOT::Math::XYZPoint(0., 0., 0.));
-            G4MagneticField* magField = new G4UniformMagField(G4ThreeVector(b_field.x(), b_field.y(), b_field.z()));
-            G4FieldManager* globalFieldMgr = G4TransportationManager::GetTransportationManager()->GetFieldManager();
-            globalFieldMgr->SetDetectorField(magField);
-            globalFieldMgr->CreateChordFinder(magField);
-        } else {
-            throw ModuleError("Magnetic field enabled, but not constant. This can't be handled by this module yet.");
-        }
+        G4MagneticField* magField = new MagFieldG4(geo_manager_);
+        G4FieldManager* globalFieldMgr = G4TransportationManager::GetTransportationManager()->GetFieldManager();
+        globalFieldMgr->SetDetectorField(magField);
+        globalFieldMgr->CreateChordFinder(magField);
     }
 
     // Loop through all detectors and set the sensitive detector action that handles the particle passage
@@ -611,4 +603,17 @@ void DepositionGeant4Module::record_module_statistics() {
     for(auto& sensor : sensors_) {
         total_charges_ += sensor->getTotalDepositedCharge();
     }
+}
+
+MagFieldG4::MagFieldG4(GeometryManager* gm) { gm_ = gm; }
+
+MagFieldG4::~MagFieldG4(){};
+
+void MagFieldG4::GetFieldValue(const double Point[4], double* Bfield) const {
+    G4cout << "Getting mag field from gm" << G4endl;
+    ROOT::Math::XYZVector bfield_vector = gm_->getMagneticField(ROOT::Math::XYZPoint(Point[0], Point[1], Point[2]));
+    G4cout << bfield_vector << G4endl;
+    Bfield[0] = bfield_vector.x();
+    Bfield[1] = bfield_vector.y();
+    Bfield[2] = bfield_vector.z();
 }

--- a/src/modules/DepositionGeant4/DepositionGeant4Module.hpp
+++ b/src/modules/DepositionGeant4/DepositionGeant4Module.hpp
@@ -135,13 +135,13 @@ namespace allpix {
         std::mutex histogram_mutex_;
     };
 
-    class MagFieldG4 : public G4MagneticField {
+    class MagneticField : public G4MagneticField {
     protected:
-        GeometryManager* gm_;
+        GeometryManager* geometry_manager_;
 
     public:
-        MagFieldG4(GeometryManager* gm);
-        ~MagFieldG4();
+        MagneticField(GeometryManager* geometry_manager);
+        ~MagneticField() = default;
         virtual void GetFieldValue(const double Point[4], double* Bfield) const;
     };
 } // namespace allpix

--- a/src/modules/DepositionGeant4/DepositionGeant4Module.hpp
+++ b/src/modules/DepositionGeant4/DepositionGeant4Module.hpp
@@ -16,9 +16,8 @@
 #include <memory>
 #include <string>
 
+#include <G4MagneticField.hh>
 #include <G4UserLimits.hh>
-
-#include "G4MagneticField.hh"
 
 #include "core/config/Configuration.hpp"
 #include "core/geometry/GeometryManager.hpp"

--- a/src/modules/DepositionGeant4/DepositionGeant4Module.hpp
+++ b/src/modules/DepositionGeant4/DepositionGeant4Module.hpp
@@ -18,6 +18,8 @@
 
 #include <G4UserLimits.hh>
 
+#include "G4MagneticField.hh"
+
 #include "core/config/Configuration.hpp"
 #include "core/geometry/GeometryManager.hpp"
 #include "core/messenger/Messenger.hpp"
@@ -132,6 +134,16 @@ namespace allpix {
 
         // Mutex used for the construction of histograms
         std::mutex histogram_mutex_;
+    };
+
+    class MagFieldG4 : public G4MagneticField {
+    protected:
+        GeometryManager* gm_;
+
+    public:
+        MagFieldG4(GeometryManager* gm);
+        ~MagFieldG4();
+        virtual void GetFieldValue(const double Point[4], double* Bfield) const;
     };
 } // namespace allpix
 

--- a/src/modules/DepositionGeant4/DepositionGeant4Module.hpp
+++ b/src/modules/DepositionGeant4/DepositionGeant4Module.hpp
@@ -140,9 +140,10 @@ namespace allpix {
         GeometryManager* geometry_manager_;
 
     public:
-        MagneticField(GeometryManager* geometry_manager);
-        ~MagneticField() = default;
-        virtual void GetFieldValue(const double Point[4], double* Bfield) const;
+        explicit MagneticField(GeometryManager* geometry_manager);
+        ~MagneticField() override = default;
+        // The Geant4 API expects a const double Point[4], not the std::array<> the linter suggests
+        virtual void GetFieldValue(const double Point[4], double* Bfield) const override; // NOLINT
     };
 } // namespace allpix
 

--- a/src/modules/MagneticFieldReader/MagneticFieldReaderModule.cpp
+++ b/src/modules/MagneticFieldReader/MagneticFieldReaderModule.cpp
@@ -76,7 +76,7 @@ void MagneticFieldReaderModule::initialize() {
                    yind >= static_cast<double>(ncells[1]) || zind < 0 || zind >= static_cast<double>(ncells[2])) {
                     return fallback_field;
                 } else {
-                    auto *field = field_mesh.get();
+                    auto* field = field_mesh.get();
 
                     auto ix = static_cast<uint64_t>(xind);
                     auto iy = static_cast<uint64_t>(yind);

--- a/src/modules/MagneticFieldReader/MagneticFieldReaderModule.cpp
+++ b/src/modules/MagneticFieldReader/MagneticFieldReaderModule.cpp
@@ -56,7 +56,7 @@ void MagneticFieldReaderModule::initialize() {
     } else if(field_model == MagneticField::MESH) {
         type = MagneticFieldType::CUSTOM;
 
-        auto fallback_field = config_.get<ROOT::Math::XYZVector>("magnetic_field_fallback", ROOT::Math::XYZVector());
+        auto fallback_field = config_.get<ROOT::Math::XYZVector>("magnetic_field", ROOT::Math::XYZVector());
         auto field_data = read_field();
 
         auto dims = field_data.getDimensionality(); // Vector dimensionality of the field (will be 3 for B-field)

--- a/src/modules/MagneticFieldReader/MagneticFieldReaderModule.cpp
+++ b/src/modules/MagneticFieldReader/MagneticFieldReaderModule.cpp
@@ -68,18 +68,10 @@ void MagneticFieldReaderModule::initialize() {
         auto fallback_field = config_.get<ROOT::Math::XYZVector>("magnetic_field_fallback", ROOT::Math::XYZVector());
         auto field_data = read_field();
 
-        auto dims = field_data.getDimensionality(); // Vector dimensionality of the field (should be 3 for B-field)
-        if(dims != 3) {
-            throw std::invalid_argument("B-field vectors were not three dimensional.");
-        }
-
-        auto cellsize = field_data.getSize();     // Physical dimensions for each cell in the field mesh
-        auto ncells = field_data.getDimensions(); // Number of cells in each direction of the field mesh
-        auto field_mesh = field_data.getData();   // The field mesh B-field data as a flattened array
-
-        if(ncells[0] * ncells[1] * ncells[2] * dims != field_mesh->size()) {
-            throw std::invalid_argument("B-field does not span the given dimensions");
-        }
+        auto dims = field_data.getDimensionality(); // Vector dimensionality of the field (will be 3 for B-field)
+        auto cellsize = field_data.getSize();       // Physical dimensions for each cell in the field mesh
+        auto ncells = field_data.getDimensions();   // Number of cells in each direction of the field mesh
+        auto field_mesh = field_data.getData();     // The field mesh B-field data as a flattened array
 
         MagneticFieldFunction function =
             [fallback_field, field_mesh, cellsize, ncells, dims](const ROOT::Math::XYZPoint& coord) {

--- a/src/modules/MagneticFieldReader/MagneticFieldReaderModule.cpp
+++ b/src/modules/MagneticFieldReader/MagneticFieldReaderModule.cpp
@@ -52,15 +52,6 @@ void MagneticFieldReaderModule::initialize() {
         MagneticFieldFunction function = [b_field](const ROOT::Math::XYZPoint&) { return b_field; };
 
         geometryManager_->setMagneticFieldFunction(function, type);
-        auto detectors = geometryManager_->getDetectors();
-        for(auto& detector : detectors) {
-            // TODO the magnetic field is calculated once for the center position of the detector. This could be extended to
-            // a function enabling a gradient in the magnetic field inside the sensor
-            auto position = detector->getPosition();
-            detector->setMagneticField(detector->getOrientation().Inverse() * geometryManager_->getMagneticField(position));
-            LOG(DEBUG) << "Magnetic field in detector " << detector->getName() << ": "
-                       << Units::display(detector->getMagneticField(detector->getLocalPosition(position)), {"T", "mT"});
-        }
         LOG(INFO) << "Set constant magnetic field: " << Units::display(b_field, {"T", "mT"});
     } else if(field_model == MagneticField::MESH) {
         type = MagneticFieldType::CUSTOM;
@@ -99,16 +90,17 @@ void MagneticFieldReaderModule::initialize() {
             };
 
         geometryManager_->setMagneticFieldFunction(function, type);
-        auto detectors = geometryManager_->getDetectors();
-        for(auto& detector : detectors) {
-            // TODO the magnetic field is calculated once for the center position of the detector. This could be extended to
-            // a function enabling a gradient in the magnetic field inside the sensor
-            auto position = detector->getPosition();
-            detector->setMagneticField(detector->getOrientation().Inverse() * geometryManager_->getMagneticField(position));
-            LOG(DEBUG) << "Magnetic field in detector " << detector->getName() << ": "
-                       << Units::display(detector->getMagneticField(detector->getLocalPosition(position)), {"T", "mT"});
-        }
         LOG(INFO) << "Set meshed magnetic field from file";
+    }
+
+    auto detectors = geometryManager_->getDetectors();
+    for(auto& detector : detectors) {
+        // TODO the magnetic field is calculated once for the center position of the detector. This could be extended to
+        // a function enabling a gradient in the magnetic field inside the sensor
+        auto position = detector->getPosition();
+        detector->setMagneticField(detector->getOrientation().Inverse() * geometryManager_->getMagneticField(position));
+        LOG(DEBUG) << "Magnetic field in detector " << detector->getName() << ": "
+                   << Units::display(detector->getMagneticField(detector->getLocalPosition(position)), {"T", "mT"});
     }
 }
 

--- a/src/modules/MagneticFieldReader/MagneticFieldReaderModule.cpp
+++ b/src/modules/MagneticFieldReader/MagneticFieldReaderModule.cpp
@@ -87,9 +87,9 @@ void MagneticFieldReaderModule::initialize() {
                 } else {
                     auto field = field_mesh.get();
 
-                    long unsigned int ix = static_cast<long unsigned int>(xind);
-                    long unsigned int iy = static_cast<long unsigned int>(yind);
-                    long unsigned int iz = static_cast<long unsigned int>(zind);
+                    auto ix = static_cast<uint64_t>(xind);
+                    auto iy = static_cast<uint64_t>(yind);
+                    auto iz = static_cast<uint64_t>(zind);
 
                     auto bfieldx = field->at(ix * ncells[1] * ncells[2] * dims + iy * ncells[2] * dims + iz * dims);
                     auto bfieldy = field->at(ix * ncells[1] * ncells[2] * dims + iy * ncells[2] * dims + iz * dims + 1);

--- a/src/modules/MagneticFieldReader/MagneticFieldReaderModule.cpp
+++ b/src/modules/MagneticFieldReader/MagneticFieldReaderModule.cpp
@@ -76,7 +76,7 @@ void MagneticFieldReaderModule::initialize() {
                    yind >= static_cast<double>(ncells[1]) || zind < 0 || zind >= static_cast<double>(ncells[2])) {
                     return fallback_field;
                 } else {
-                    auto field = field_mesh.get();
+                    auto *field = field_mesh.get();
 
                     auto ix = static_cast<uint64_t>(xind);
                     auto iy = static_cast<uint64_t>(yind);

--- a/src/modules/MagneticFieldReader/MagneticFieldReaderModule.hpp
+++ b/src/modules/MagneticFieldReader/MagneticFieldReaderModule.hpp
@@ -17,6 +17,7 @@
 #include "core/config/Configuration.hpp"
 #include "core/geometry/GeometryManager.hpp"
 #include "core/messenger/Messenger.hpp"
+#include "tools/field_parser.h"
 
 #include "core/module/Module.hpp"
 
@@ -34,6 +35,7 @@ namespace allpix {
          */
         enum class MagneticField {
             CONSTANT, ///< Constant magnetic field
+            MESH,     ///< Magnetic field defined by a mesh
         };
 
     public:
@@ -52,5 +54,12 @@ namespace allpix {
 
     private:
         GeometryManager* geometryManager_;
+
+        /**
+         * @brief Read field from a file in init or apf format
+         * @return Data of the field read from file
+         */
+        FieldData<double> read_field();
+        static FieldParser<double> field_parser_;
     };
 } // namespace allpix


### PR DESCRIPTION
Work-in-progress addition to the `MagneticFieldReader` module to allow loading from mesh files, much like in the `ElectricFieldReader` case.

Currently working:
* Loading a set of B-field 3-vectors from a file
* Making sure GEANT4 reacts to the non-constant field across the world volume
* Fallback config option for a constant field outside the specified mesh volume (defaults to 0T)

Still to do:
* Config option to specify the volume centre (currently defaults to centring the mesh about the origin)
* Config option to specify volume start (e.g. pinning bottom-left corner of mesh to a coordinate, rather than centring the mesh about a location).
* Create output plots of loaded field
* Documentation and tests

Very happy to receive comments and suggestions on the current implementation!