### PR TITLE
Option to allow CSADigitizer clocks to be synched with simulation time

### DIFF
--- a/src/modules/CSADigitizer/CSADigitizerModule.cpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.cpp
@@ -83,7 +83,7 @@ CSADigitizerModule::CSADigitizerModule(Configuration& config, Messenger* messeng
     }
 
     // Synchronize the clock binning to global simulation time
-    sync_sim_time_ = config_.get<bool>("sync_sim_time");
+    sync_event_time_ = config_.get<bool>("sync_event_time");
     tdc_offset_ = config_.get<double>("tdc_offset");
 
     sigmaNoise_ = config_.get<double>("sigma_noise");
@@ -325,7 +325,7 @@ void CSADigitizerModule::run(Event* event) {
         pulses.emplace_back(pixel, amplified_pulse, &pixel_charge);
 
         double time_offset = tdc_offset_;
-        if(sync_sim_time_) {
+        if(sync_event_time_) {
             time_offset += pixel_charge.getGlobalTime();
         }
 

--- a/src/modules/CSADigitizer/CSADigitizerModule.cpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.cpp
@@ -50,6 +50,7 @@ CSADigitizerModule::CSADigitizerModule(Configuration& config, Messenger* messeng
     config_.setDefault<int>("output_plots_scale", Units::get(30, "ke"));
     config_.setDefault<int>("output_plots_bins", 100);
     config_.setDefault<bool>("sync_sim_time", false);
+    config_.setDefault<double>("tdc_offset", Units::get(0.0, "ns"));
 
     if(model_ == DigitizerType::SIMPLE) {
         // defaults for the "simple" parametrisation
@@ -83,6 +84,7 @@ CSADigitizerModule::CSADigitizerModule(Configuration& config, Messenger* messeng
 
     // Synchronize the clock binning to global simulation time
     sync_sim_time_ = config_.get<bool>("sync_sim_time");
+    tdc_offset_    = config_.get<double>("tdc_offset");
 
     sigmaNoise_ = config_.get<double>("sigma_noise");
     threshold_ = config_.get<double>("threshold");
@@ -322,9 +324,9 @@ void CSADigitizerModule::run(Event* event) {
         // Store amplified pulse fir dispatch
         pulses.emplace_back(pixel, amplified_pulse, &pixel_charge);
 
-        double time_offset = 0.0;
+        double time_offset = tdc_offset_;
         if(sync_sim_time_) {
-            time_offset = pixel_charge.getGlobalTime();
+            time_offset += pixel_charge.getGlobalTime();
         }
 
         // Find threshold crossing - if any:
@@ -394,7 +396,7 @@ std::tuple<bool, unsigned int, double> CSADigitizerModule::get_toa(double timest
 
     // Find the point where the signal crosses the threshold, latch ToA
     while(arrival_time < integration_time_+time_offset) {
-        auto bin = pulse.at(static_cast<size_t>(std::floor(arrival_time / timestep)));
+        auto bin = pulse.at(static_cast<size_t>(std::floor((arrival_time-time_offset) / timestep)));
         if(is_above_threshold(bin)) {
             threshold_crossed = true;
             break;

--- a/src/modules/CSADigitizer/CSADigitizerModule.cpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.cpp
@@ -359,7 +359,7 @@ void CSADigitizerModule::run(Event* event) {
 
         // Add the hit to the hitmap
         hits.emplace_back(
-            pixel, time, pixel_charge.getGlobalTime() + std::get<2>(arrival), charge, &pixel_charge, &pulses.back());
+            pixel, time, std::get<2>(arrival)-tdc_offset_, charge, &pixel_charge, &pulses.back());
     }
 
     // Output summary and update statistics
@@ -423,9 +423,10 @@ unsigned int CSADigitizerModule::get_tot(double timestep, double arrival_time, c
     };
 
     // Start calculation from the next ToT clock cycle following the threshold crossing
-    auto tot_time = clockToT_ * std::ceil(arrival_time / clockToT_);
-    while(tot_time < integration_time_) {
-        auto bin = pulse.at(static_cast<size_t>(std::floor(tot_time / timestep)));
+    auto tot_time0 = clockToT_ * std::ceil(arrival_time / clockToT_); 
+    auto tot_time = tot_time0;
+    while(tot_time < tot_time0+integration_time_) {
+        auto bin = pulse.at(static_cast<size_t>(std::floor((tot_time-tot_time0) / timestep)));
         if(is_below_threshold(bin)) {
             break;
         }

--- a/src/modules/CSADigitizer/CSADigitizerModule.cpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.cpp
@@ -49,7 +49,7 @@ CSADigitizerModule::CSADigitizerModule(Configuration& config, Messenger* messeng
     config_.setDefault<bool>("output_plots", config_.get<bool>("output_pulsegraphs"));
     config_.setDefault<int>("output_plots_scale", Units::get(30, "ke"));
     config_.setDefault<int>("output_plots_bins", 100);
-    config_.setDefault<bool>("sync_sim_time", false);
+    config_.setDefault<bool>("sync_event_time", false);
     config_.setDefault<double>("tdc_offset", Units::get(0.0, "ns"));
 
     if(model_ == DigitizerType::SIMPLE) {

--- a/src/modules/CSADigitizer/CSADigitizerModule.cpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.cpp
@@ -49,6 +49,7 @@ CSADigitizerModule::CSADigitizerModule(Configuration& config, Messenger* messeng
     config_.setDefault<bool>("output_plots", config_.get<bool>("output_pulsegraphs"));
     config_.setDefault<int>("output_plots_scale", Units::get(30, "ke"));
     config_.setDefault<int>("output_plots_bins", 100);
+    config_.setDefault<bool>("sync_sim_time", false);
 
     if(model_ == DigitizerType::SIMPLE) {
         // defaults for the "simple" parametrisation
@@ -79,6 +80,9 @@ CSADigitizerModule::CSADigitizerModule(Configuration& config, Messenger* messeng
         store_tot_ = true;
         clockToT_ = config_.get<double>("clock_bin_tot");
     }
+
+    // Synchronize the clock binning to global simulation time
+    sync_sim_time_ = config_.get<bool>("sync_sim_time");
 
     sigmaNoise_ = config_.get<double>("sigma_noise");
     threshold_ = config_.get<double>("threshold");
@@ -318,8 +322,13 @@ void CSADigitizerModule::run(Event* event) {
         // Store amplified pulse fir dispatch
         pulses.emplace_back(pixel, amplified_pulse, &pixel_charge);
 
+        double time_offset = 0.0;
+        if(sync_sim_time_) {
+            time_offset = pixel_charge.getGlobalTime();
+        }
+
         // Find threshold crossing - if any:
-        auto arrival = get_toa(timestep, amplified_pulse);
+        auto arrival = get_toa(timestep, amplified_pulse, time_offset);
         if(!std::get<0>(arrival)) {
             LOG(DEBUG) << "Amplified signal never crossed threshold, continuing.";
             continue;
@@ -367,12 +376,12 @@ void CSADigitizerModule::run(Event* event) {
     }
 }
 
-std::tuple<bool, unsigned int, double> CSADigitizerModule::get_toa(double timestep, const std::vector<double>& pulse) const {
+std::tuple<bool, unsigned int, double> CSADigitizerModule::get_toa(double timestep, const std::vector<double>& pulse, double time_offset) const {
 
     LOG(TRACE) << "Calculating time-of-arrival";
     bool threshold_crossed = false;
-    unsigned int comparator_cycles = 0;
-    double arrival_time = 0;
+    unsigned int comparator_cycles = std::floor(time_offset / clockToA_);
+    double arrival_time = time_offset;
 
     // Lambda for threshold calculation:
     auto is_above_threshold = [this](double bin) {
@@ -384,7 +393,7 @@ std::tuple<bool, unsigned int, double> CSADigitizerModule::get_toa(double timest
     };
 
     // Find the point where the signal crosses the threshold, latch ToA
-    while(arrival_time < integration_time_) {
+    while(arrival_time < integration_time_+time_offset) {
         auto bin = pulse.at(static_cast<size_t>(std::floor(arrival_time / timestep)));
         if(is_above_threshold(bin)) {
             threshold_crossed = true;

--- a/src/modules/CSADigitizer/CSADigitizerModule.cpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.cpp
@@ -84,7 +84,7 @@ CSADigitizerModule::CSADigitizerModule(Configuration& config, Messenger* messeng
 
     // Synchronize the clock binning to global simulation time
     sync_sim_time_ = config_.get<bool>("sync_sim_time");
-    tdc_offset_    = config_.get<double>("tdc_offset");
+    tdc_offset_ = config_.get<double>("tdc_offset");
 
     sigmaNoise_ = config_.get<double>("sigma_noise");
     threshold_ = config_.get<double>("threshold");
@@ -378,7 +378,8 @@ void CSADigitizerModule::run(Event* event) {
     }
 }
 
-std::tuple<bool, unsigned int, double> CSADigitizerModule::get_toa(double timestep, const std::vector<double>& pulse, double time_offset) const {
+std::tuple<bool, unsigned int, double>
+CSADigitizerModule::get_toa(double timestep, const std::vector<double>& pulse, double time_offset) const {
 
     LOG(TRACE) << "Calculating time-of-arrival";
     bool threshold_crossed = false;
@@ -395,8 +396,8 @@ std::tuple<bool, unsigned int, double> CSADigitizerModule::get_toa(double timest
     };
 
     // Find the point where the signal crosses the threshold, latch ToA
-    while(arrival_time < integration_time_+time_offset) {
-        auto bin = pulse.at(static_cast<size_t>(std::floor((arrival_time-time_offset) / timestep)));
+    while(arrival_time < integration_time_ + time_offset) {
+        auto bin = pulse.at(static_cast<size_t>(std::floor((arrival_time - time_offset) / timestep)));
         if(is_above_threshold(bin)) {
             threshold_crossed = true;
             break;

--- a/src/modules/CSADigitizer/CSADigitizerModule.cpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.cpp
@@ -383,7 +383,7 @@ CSADigitizerModule::get_toa(double timestep, const std::vector<double>& pulse, d
 
     LOG(TRACE) << "Calculating time-of-arrival";
     bool threshold_crossed = false;
-    unsigned int comparator_cycles = static_cast<unsigned int>(std::floor(time_offset / clockToA_));
+    auto comparator_cycles = static_cast<unsigned int>(std::floor(time_offset / clockToA_));
     double arrival_time = time_offset;
 
     // Lambda for threshold calculation:

--- a/src/modules/CSADigitizer/CSADigitizerModule.cpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.cpp
@@ -383,7 +383,7 @@ CSADigitizerModule::get_toa(double timestep, const std::vector<double>& pulse, d
 
     LOG(TRACE) << "Calculating time-of-arrival";
     bool threshold_crossed = false;
-    unsigned int comparator_cycles = std::floor(time_offset / clockToA_);
+    unsigned int comparator_cycles = static_cast<unsigned int>(std::floor(time_offset / clockToA_));
     double arrival_time = time_offset;
 
     // Lambda for threshold calculation:

--- a/src/modules/CSADigitizer/CSADigitizerModule.hpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.hpp
@@ -73,7 +73,7 @@ namespace allpix {
     private:
         // Control of module output settings
         bool output_plots_{}, output_pulsegraphs_{};
-        bool store_tot_{false}, store_toa_{false}, ignore_polarity_{};
+        bool store_tot_{false}, store_toa_{false}, sync_sim_time_{false}, ignore_polarity_{};
         Messenger* messenger_;
         DigitizerType model_;
 
@@ -99,7 +99,7 @@ namespace allpix {
          * @return Tuple containing information about threshold crossing: Boolean (true if crossed), unsigned int (number
          *         of ToA clock cycles before crossing) and double (time of crossing)
          */
-        std::tuple<bool, unsigned int, double> get_toa(double timestep, const std::vector<double>& pulse) const;
+        std::tuple<bool, unsigned int, double> get_toa(double timestep, const std::vector<double>& pulse, double time_offset) const;
 
         /**
          * @brief Calculate time-over-threshold

--- a/src/modules/CSADigitizer/CSADigitizerModule.hpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.hpp
@@ -99,7 +99,8 @@ namespace allpix {
          * @return Tuple containing information about threshold crossing: Boolean (true if crossed), unsigned int (number
          *         of ToA clock cycles before crossing) and double (time of crossing)
          */
-        std::tuple<bool, unsigned int, double> get_toa(double timestep, const std::vector<double>& pulse, double time_offset) const;
+        std::tuple<bool, unsigned int, double>
+        get_toa(double timestep, const std::vector<double>& pulse, double time_offset) const;
 
         /**
          * @brief Calculate time-over-threshold

--- a/src/modules/CSADigitizer/CSADigitizerModule.hpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.hpp
@@ -81,7 +81,7 @@ namespace allpix {
         std::unique_ptr<TFormula> calculate_impulse_response_;
 
         // Parameters of the electronics: Noise, time-over-threshold logic
-        double sigmaNoise_{}, clockToT_{}, clockToA_{}, threshold_{};
+        double sigmaNoise_{}, clockToT_{}, clockToA_{}, threshold_{}, tdc_offset_{};
 
         // Helper variables for transfer function
         double integration_time_{};

--- a/src/modules/CSADigitizer/CSADigitizerModule.hpp
+++ b/src/modules/CSADigitizer/CSADigitizerModule.hpp
@@ -73,7 +73,7 @@ namespace allpix {
     private:
         // Control of module output settings
         bool output_plots_{}, output_pulsegraphs_{};
-        bool store_tot_{false}, store_toa_{false}, sync_sim_time_{false}, ignore_polarity_{};
+        bool store_tot_{false}, store_toa_{false}, sync_event_time_{false}, ignore_polarity_{};
         Messenger* messenger_;
         DigitizerType model_;
 

--- a/src/modules/CSADigitizer/README.md
+++ b/src/modules/CSADigitizer/README.md
@@ -50,6 +50,8 @@ If this behavior is not desired, the `ignore_polarity` parameter can be set to c
 * `ignore_polarity`: Select whether polarity of the threshold is ignored, i.e. the absolute values are compared, or if polarity is taken into account. Defaults to `false`.
 * `clock_bin_toa`: Duration of a clock cycle for the time-of-arrival (ToA) clock. If set, the output timestamp is delivered in units of ToA clock cycles, otherwise in nanoseconds.
 * `clock_bin_tot`: Duration of a clock cycle for the time-over-threshold (ToT) clock. If set, the output charge is delivered as time over threshold in units of ToT clock cycles, otherwise the pulse integral is stored instead.
+* `sync_sim_time`: Aligns the clock cycle with global 0 time. Defaults to false.
+* `tdc_offset`: Adds an offset to the global time for this digitizer. Defaults to 0ns.
 
 ### Parameters for the simplified model
 

--- a/src/modules/CSADigitizer/README.md
+++ b/src/modules/CSADigitizer/README.md
@@ -50,7 +50,7 @@ If this behavior is not desired, the `ignore_polarity` parameter can be set to c
 * `ignore_polarity`: Select whether polarity of the threshold is ignored, i.e. the absolute values are compared, or if polarity is taken into account. Defaults to `false`.
 * `clock_bin_toa`: Duration of a clock cycle for the time-of-arrival (ToA) clock. If set, the output timestamp is delivered in units of ToA clock cycles, otherwise in nanoseconds.
 * `clock_bin_tot`: Duration of a clock cycle for the time-over-threshold (ToT) clock. If set, the output charge is delivered as time over threshold in units of ToT clock cycles, otherwise the pulse integral is stored instead.
-* `sync_sim_time`: Aligns the clock cycle with global 0 time. Defaults to false.
+* `sync_event_time`: Aligns the clock cycle to start counting with the global event time as opposed to starting at the beginning of the detected pulse time. Defaults to false.
 * `tdc_offset`: Adds an offset to the global time for this digitizer. Defaults to 0ns.
 
 ### Parameters for the simplified model


### PR DESCRIPTION
Adds configurations to the CSADigitizer:
`sync_sim_time`
`tdc_offset`

Allowing the ToA and ToT clocks to sync with the global simulation time rather than being locked to the start of a PixelCharge pulse.