### PR TITLE
Add configuration to set particle start time within uniform time window

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -31,6 +31,7 @@ The following authors, in alphabetical order, have developed or contributed to A
 * Malinda de Silva, DESY, [ldesilva](https://gitlab.cern.ch/ldesilva)
 * Mauricio Donatti, Brazilian Synchrotron Light Laboratory, [mmdonatti](https://github.com/mmdonatti)
 * Katharina Dort, University of Gießen, [kdort](https://gitlab.cern.ch/kdort)
+* Simon Gardner, University of Glasgow, [simonge](https://github.com/simonge)
 * Neal Gauvin, Université de Genève, [ngauvin](https://gitlab.cern.ch/ngauvin)
 * Yajun He, DESY, [yajun](https://gitlab.cern.ch/yajun)
 * Ryan Heller, LBNL, [heller3](https://github.com/heller3)

--- a/src/modules/DepositionGeant4/GeneratorActionG4.cpp
+++ b/src/modules/DepositionGeant4/GeneratorActionG4.cpp
@@ -272,9 +272,11 @@ GeneratorActionG4::GeneratorActionG4(const Configuration& config)
             single_source->SetNumberOfParticles(1);
             single_source->SetParticleDefinition(particle);
             // Set the primary track's start time in for the current event to zero:
-            single_source->SetParticleTime(0.0);
+            time_        = config_.get<double>("source_time",        Units::get(0.0, "ns"));
+            time_window_ = config_.get<double>("source_time_window", Units::get(0.0, "ns"));
+            single_source->SetParticleTime(time_);
         }
-
+        
         // Set energy parameters
         single_source->GetEneDist()->SetEnergyDisType("Gauss");
         single_source->GetEneDist()->SetMonoEnergy(config_.get<double>("source_energy"));
@@ -337,8 +339,6 @@ void GeneratorActionG4::GeneratePrimaries(G4Event* event) {
             // Set global parameters of the source
             single_source->SetNumberOfParticles(1);
             single_source->SetParticleDefinition(particle);
-            // Set the primary track's start time in for the current event to zero:
-            single_source->SetParticleTime(0.0);
 
             // mark the initialization done
             initialize_ion_as_particle_ = false;
@@ -348,6 +348,12 @@ void GeneratorActionG4::GeneratePrimaries(G4Event* event) {
         } else {
             throw InvalidValueError(config_, "particle_type", "failed to fetch or create ion.");
         }
+    }
+
+    // Set the time of the particle source within the time window
+    if(time_window_ > 0) {
+        double event_time = time_ + G4UniformRand() * time_window_;
+        particle_source_->SetParticleTime(event_time);
     }
 
     particle_source_->GeneratePrimaryVertex(event);

--- a/src/modules/DepositionGeant4/GeneratorActionG4.cpp
+++ b/src/modules/DepositionGeant4/GeneratorActionG4.cpp
@@ -272,11 +272,11 @@ GeneratorActionG4::GeneratorActionG4(const Configuration& config)
             single_source->SetNumberOfParticles(1);
             single_source->SetParticleDefinition(particle);
             // Set the primary track's start time in for the current event to zero:
-            time_        = config_.get<double>("source_time",        Units::get(0.0, "ns"));
+            time_ = config_.get<double>("source_time", Units::get(0.0, "ns"));
             time_window_ = config_.get<double>("source_time_window", Units::get(0.0, "ns"));
             single_source->SetParticleTime(time_);
         }
-        
+
         // Set energy parameters
         single_source->GetEneDist()->SetEnergyDisType("Gauss");
         single_source->GetEneDist()->SetMonoEnergy(config_.get<double>("source_energy"));

--- a/src/modules/DepositionGeant4/GeneratorActionG4.cpp
+++ b/src/modules/DepositionGeant4/GeneratorActionG4.cpp
@@ -352,8 +352,9 @@ void GeneratorActionG4::GeneratePrimaries(G4Event* event) {
 
     // Set the time of the particle source within the time window
     if(time_window_ > 0) {
+        auto* single_source = particle_source_->GetCurrentSource();
         double event_time = time_ + G4UniformRand() * time_window_;
-        particle_source_->SetParticleTime(event_time);
+        single_source->SetParticleTime(event_time);
     }
 
     particle_source_->GeneratePrimaryVertex(event);

--- a/src/modules/DepositionGeant4/GeneratorActionG4.hpp
+++ b/src/modules/DepositionGeant4/GeneratorActionG4.hpp
@@ -70,6 +70,10 @@ namespace allpix {
         std::string particle_type_;
 
         bool initialize_ion_as_particle_{false};
+
+        double time_{0.0};
+        double time_window_{0.0};
+        
     };
 
     /**

--- a/src/modules/DepositionGeant4/GeneratorActionG4.hpp
+++ b/src/modules/DepositionGeant4/GeneratorActionG4.hpp
@@ -73,7 +73,6 @@ namespace allpix {
 
         double time_{0.0};
         double time_window_{0.0};
-        
     };
 
     /**

--- a/src/modules/DepositionGeant4/README.md
+++ b/src/modules/DepositionGeant4/README.md
@@ -85,6 +85,8 @@ This module requires an installation Geant4.
 * `source_energy` : Mean kinetic energy of the generated particles.
 * `source_energy_spread` : Energy spread of the source.
 * `source_position` : Position of the particle source in the world geometry.
+* `source_time` : Offset from 0 to start the Geant4 particles. Default 0ns.
+* `source_time_window` : Range of times starting from the offset to randomly generate over uniformly. Default 0ns (off).
 * `source_type` : Shape of the source: **beam** (default), **point**, **square**, **sphere**, **macro**.
 * `cutoff_time` : Maximum lifetime of particles to be propagated in the simulation. This setting is passed to Geant4 as user limit and assigned to all sensitive volumes. Particles and decay products are only propagated and decayed up the this time limit and all remaining kinetic energy is deposited in the sensor it reached the time limit in. Defaults to 221s (to ensure proper gamma creation for the Cs137 decay).
 Note: Neutrons have a lifetime of 882 seconds and will not be propagated in the simulation with the default `cutoff_time`.


### PR DESCRIPTION
Adds configurations to the `DepositionGeant4` module, allowing the generation of uniform random event start times using:
`source_time`
`source_time_window`