### PR TITLE
Adding Cesium Lead Bromide as active sensor material

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -24,6 +24,7 @@ The following authors, in alphabetical order, have developed or contributed to A
 * Koen van den Brandt, Nikhef, [kvandenb](https://gitlab.cern.ch/kvandenb)
 * Ben Bruers, DESY, [bbrueers](https://gitlab.cern.ch/bbrueers)
 * Carsten Daniel Burgard, DESY, [cburgard](https://gitlab.cern.ch/cburgard)
+* Raul Back Campanelli, Brazilian Synchrotron Light Laboratory, [raul-campanelli](https://github.com/raul-campanelli)
 * Maximilian Felix Caspar, DESY, [mcaspar](https://gitlab.cern.ch/mcaspar)
 * Liejian Chen, Institute of High Energy Physics Beijing, [chenlj](https://github.com/chenlj)
 * Naomi Davis, DESY, [naomi](https://gitlab.cern.ch/naomi)

--- a/doc/usermanual/06_models/01_material_properties.md
+++ b/doc/usermanual/06_models/01_material_properties.md
@@ -30,7 +30,7 @@ composition and of vendors. The sources for the chosen default values are provid
 | Cadmium Zinc Telluride $`(\ce{Cd_{0.8}Zn_{0.2}Te})`$ | 4.6             | 0.14        | \[[@CdZnTe_Creation], [@CdZnTe_Fano]\] |
 | Diamond                                              | 13.1            | 0.382       | \[[@Diamond_Creation_Fano]\]           |
 | Silicon Carbide $`(\ce{{4H-}SiC})`$                  | 7.6             | 0.1         | \[[@SiC_Creation], [@SiC_Fano]\]       |
-
+| Cesium Lead Bromide (CsPbBr<sub>3</sub>)                      | 5.3             | 0.1         | \[[@CsPbBr3_Creation],[@CsPbBr3_Fano]\]|                                        |
 
 It should be noted that material properties such as the density and composition of materials are defined only in case of
 constructing a Geant4 geometry via the `GeometryBuilderGeant4` module, therefore these values are implemented within the
@@ -49,3 +49,5 @@ respective module.
 [@Diamond_Creation_Fano]: https://doi.org/10.1002/pssa.201600195
 [@SiC_Creation]: https://doi.org/10.1109/NSSMIC.2005.1596542
 [@SiC_Fano]: https://doi.org/10.1016/j.nima.2010.08.046
+[@CsPbBr3_Creation]: https://doi.org/10.1038/s41467-018-04073-3
+[@CsPbBr3_Fano]: https://doi.org/10.1038/s41566-020-00727-1

--- a/src/core/geometry/DetectorModel.hpp
+++ b/src/core/geometry/DetectorModel.hpp
@@ -49,6 +49,7 @@ namespace allpix {
         DIAMOND,                ///< Diamond
         SILICON_CARBIDE,        ///< Silicon Carbide
         GALLIUM_NITRIDE,        ///< Gallium Nitride
+        CESIUM_LEAD_BROMIDE,    ///< CsPbBr3 (Perovskite)
     };
 
     /**

--- a/src/modules/GeometryBuilderGeant4/MaterialManager.cpp
+++ b/src/modules/GeometryBuilderGeant4/MaterialManager.cpp
@@ -89,6 +89,7 @@ void Materials::set(const std::string& name, G4Material* material) { materials_.
  *   - silicon carbide
  *   - titanium grade 5
  *   - vacuum
+ *   - cesium_lead_bromide
  */
 void Materials::init_materials() {
     G4NistManager* nistman = G4NistManager::Instance();
@@ -127,6 +128,8 @@ void Materials::init_materials() {
     auto* Sn = nistman->FindOrBuildElement("Sn");
     auto* Te = nistman->FindOrBuildElement("Te");
     auto* Pb = nistman->FindOrBuildElement("Pb");
+    auto* Cs = nistman->FindOrBuildElement("Cs");
+    auto* Br = nistman->FindOrBuildElement("Br");
 
     // Create Epoxy material
     auto* Epoxy = new G4Material("Epoxy", 1.3 * CLHEP::g / CLHEP::cm3, 3);
@@ -219,4 +222,16 @@ void Materials::init_materials() {
 
     // Add vacuum
     materials_["vacuum"] = new G4Material("Vacuum", 1, 1.008 * CLHEP::g / CLHEP::mole, CLHEP::universe_mean_density);
+
+    // Create Cesium-Lead Bromide
+    // Increasingly studied material for hard X-ray detection
+    // https://doi.org/10.1063/5.0151902
+    // https://doi.org/10.1038/s41598-024-74384-7
+
+    auto* CsPbBr3 = new G4Material("CsPbBr3", 4.42 * CLHEP::g / CLHEP::cm3, 3);
+    CsPbBr3->AddElement(Cs, 1);
+    CsPbBr3->AddElement(Pb, 1);
+    CsPbBr3->AddElement(Br, 3);
+    materials_["cesium_lead_bromide"] = CsPbBr3;
+
 }

--- a/src/physics/MaterialProperties.hpp
+++ b/src/physics/MaterialProperties.hpp
@@ -30,7 +30,8 @@ namespace allpix {
         {SensorMaterial::CADMIUM_TELLURIDE, 4.43e-6}, // https://doi.org/10.1016/0029-554X(74)90662-4
         {SensorMaterial::CADMIUM_ZINC_TELLURIDE, 4.6e-6},
         {SensorMaterial::DIAMOND, 13.1e-6},         // https://doi.org/10.1002/pssa.201600195
-        {SensorMaterial::SILICON_CARBIDE, 7.6e-6}}; // https://doi.org/10.1109/NSSMIC.2005.1596542
+        {SensorMaterial::SILICON_CARBIDE, 7.6e-6}, // https://doi.org/10.1109/NSSMIC.2005.1596542
+        {SensorMaterial::CESIUM_LEAD_BROMIDE,5.3e-6}}; // https://doi.org/10.1038/s41467-018-04073-3
 
     /**
      * @brief Fano factors for different materials
@@ -44,8 +45,8 @@ namespace allpix {
         {SensorMaterial::CADMIUM_TELLURIDE, 0.24},      // https://doi.org/10.1016/j.nima.2018.09.025
         {SensorMaterial::CADMIUM_ZINC_TELLURIDE, 0.14}, // https://doi.org/10.1109/23.322857
         {SensorMaterial::DIAMOND, 0.382},               // https://doi.org/10.1002/pssa.201600195
-        {SensorMaterial::SILICON_CARBIDE, 0.1}};        // https://doi.org/10.1016/j.nima.2010.08.046
-
+        {SensorMaterial::SILICON_CARBIDE, 0.1},        // https://doi.org/10.1016/j.nima.2010.08.046
+        {SensorMaterial::CESIUM_LEAD_BROMIDE,0.1}};                // Not yet measured, but assumed by authors https://doi.org/10.1038/s41566-020-00727-1
 } // namespace allpix
 
 #endif /* ALLPIX_PROPERTIES_H */


### PR DESCRIPTION
This contribution adds Cesium Lead Bromide (CsPbBr3) to the list of active materials. This material is being extensively investigated as photo-active sensor for hard X-ray detection, so we made a few changes to make Allpix Squared compatible to this material. All changes were made in accordance with the official FAQ documentation. While the Fano
factor has not yet been reported (assumed to equal 0.1 by many authors), other properties (such as ionization energy of 5.3 eV) are implemented here. Carrier mobility can be simulated using the constant_mobility model, with values ranging from 11 to 128 cm2/Vs for holes and from 28 to 160 cm2/Vs for electrons.

https://doi.org/10.1038/s41598-024-74384-7
https://doi.org/10.1002/adom.201600704
https://www.nature.com/articles/s41467-021-21805-0