### PR TITLE
fix time precision when saving PixelHit objects with TextWriter

### DIFF
--- a/src/objects/PixelHit.cpp
+++ b/src/objects/PixelHit.cpp
@@ -117,7 +117,8 @@ std::vector<const MCParticle*> PixelHit::getPrimaryMCParticles() const {
 
 void PixelHit::print(std::ostream& out) const {
     out << "PixelHit " << this->getIndex().X() << ", " << this->getIndex().Y() << ", " << this->getSignal() << ", "
-        << this->getLocalTime() << ", " << this->getGlobalTime() << ", " << this->getPixel().getGlobalCenter().X() << ", "
+        << std::setprecision(std::numeric_limits<double>::max_digits10) << this->getLocalTime() << ", "
+        << this->getGlobalTime() << std::setprecision(6) << ", " << this->getPixel().getGlobalCenter().X() << ", "
         << this->getPixel().getGlobalCenter().Y() << ", " << this->getPixel().getGlobalCenter().Z();
 }
 


### PR DESCRIPTION
Hi!

this is a suggestion to fix the precision of the local and global time when writing PixelHit objects with the TextWriter module. 

Time values written to text files only had 6 digits, causing precision issues when simulating e.g. the Timepix3 response for more than ~1 ms (with ToA in nanoseconds).

Cheers,
Thomas