### PR TITLE
Gain histogram

### DIFF
--- a/src/modules/GenericPropagation/GenericPropagationModule.cpp
+++ b/src/modules/GenericPropagation/GenericPropagationModule.cpp
@@ -233,27 +233,27 @@ void GenericPropagationModule::initialize() {
             gain_primary_histo_ = CreateHistogram<TH1D>(
                 "gain_primary_histo",
                 "Gain per primarily induced charge carrier group after propagation;gain;number of groups transported",
-                24,
+                49,
                 1,
-                25);
+                50);
             gain_all_histo_ =
                 CreateHistogram<TH1D>("gain_all_histo",
                                       "Gain per charge carrier group after propagation;gain;number of groups transported",
-                                      24,
+                                      49,
                                       1,
-                                      25);
+                                      50);
             gain_e_histo_ =
                 CreateHistogram<TH1D>("gain_e_histo",
                                       "Gain per primary electron group after propagation;gain;number of groups transported",
-                                      24,
+                                      49,
                                       1,
-                                      25);
+                                      50);
             gain_h_histo_ =
                 CreateHistogram<TH1D>("gain_h_histo",
                                       "Gain per primary hole group after propagation;gain;number of groups transported",
-                                      24,
+                                      49,
                                       1,
-                                      25);
+                                      50);
             multiplication_level_histo_ = CreateHistogram<TH1D>(
                 "multiplication_level_histo",
                 "Multiplication level of propagated charge carriers;multiplication level;charge carriers",

--- a/src/modules/GenericPropagation/GenericPropagationModule.cpp
+++ b/src/modules/GenericPropagation/GenericPropagationModule.cpp
@@ -81,6 +81,7 @@ GenericPropagationModule::GenericPropagationModule(Configuration& config,
     config_.setDefault<bool>("output_plots_align_pixels", false);
     config_.setDefault<double>("output_plots_theta", 0.0f);
     config_.setDefault<double>("output_plots_phi", 0.0f);
+    config_.setDefault<int>("output_max_gain_histo",25);
 
     // Set defaults for charge carrier propagation:
     config_.setDefault<bool>("propagate_electrons", true);
@@ -98,6 +99,7 @@ GenericPropagationModule::GenericPropagationModule(Configuration& config,
     config_.setDefault<std::string>("multiplication_model", "none");
     config_.setDefault<double>("multiplication_threshold", 1e-2);
     config_.setDefault<unsigned int>("max_multiplication_level", 5);
+
 
     // Copy some variables from configuration to avoid lookups:
     temperature_ = config_.get<double>("temperature");
@@ -118,6 +120,12 @@ GenericPropagationModule::GenericPropagationModule(Configuration& config,
     charge_per_step_ = config_.get<unsigned int>("charge_per_step");
     max_charge_groups_ = config_.get<unsigned int>("max_charge_groups");
     max_multiplication_level_ = config.get<unsigned int>("max_multiplication_level");
+    output_max_gain_histo_ = config.get<int>("output_max_gain_histo");
+
+    // Avoids wrong gain histogram inputs
+    if(output_max_gain_histo_ < 2) {
+        throw std::runtime_error("Config error: 'output_max_gain_histo' must be >= 2.");
+    }
 
     // Enable multithreading of this module if multithreading is enabled and no per-event output plots are requested:
     // FIXME: Review if this is really the case or we can still use multithreading
@@ -233,27 +241,27 @@ void GenericPropagationModule::initialize() {
             gain_primary_histo_ = CreateHistogram<TH1D>(
                 "gain_primary_histo",
                 "Gain per primarily induced charge carrier group after propagation;gain;number of groups transported",
-                49,
+                output_max_gain_histo_ - 1,
                 1,
-                50);
+                output_max_gain_histo_);
             gain_all_histo_ =
                 CreateHistogram<TH1D>("gain_all_histo",
                                       "Gain per charge carrier group after propagation;gain;number of groups transported",
-                                      49,
+                                      output_max_gain_histo_ - 1,
                                       1,
-                                      50);
+                                      output_max_gain_histo_);
             gain_e_histo_ =
                 CreateHistogram<TH1D>("gain_e_histo",
                                       "Gain per primary electron group after propagation;gain;number of groups transported",
-                                      49,
+                                      output_max_gain_histo_ - 1,
                                       1,
-                                      50);
+                                      output_max_gain_histo_);
             gain_h_histo_ =
                 CreateHistogram<TH1D>("gain_h_histo",
                                       "Gain per primary hole group after propagation;gain;number of groups transported",
-                                      49,
+                                      output_max_gain_histo_ - 1,
                                       1,
-                                      50);
+                                      output_max_gain_histo_);
             multiplication_level_histo_ = CreateHistogram<TH1D>(
                 "multiplication_level_histo",
                 "Multiplication level of propagated charge carriers;multiplication level;charge carriers",

--- a/src/modules/GenericPropagation/GenericPropagationModule.hpp
+++ b/src/modules/GenericPropagation/GenericPropagationModule.hpp
@@ -115,7 +115,7 @@ namespace allpix {
         unsigned int charge_per_step_{};
         unsigned int max_charge_groups_{};
         unsigned int max_multiplication_level_{};
-
+        int output_max_gain_histo_{};
         // Models for electron and hole mobility and lifetime
         Mobility mobility_;
         Recombination recombination_;

--- a/src/modules/GenericPropagation/README.md
+++ b/src/modules/GenericPropagation/README.md
@@ -90,6 +90,7 @@ This module requires an installation of Eigen3.
 * `output_animations_marker_size` : Scaling for the markers on the animation, defaults to one. The markers are already internally scaled to the charge of their step, normalized to the maximum charge.
 * `output_animations_contour_max_scaling` : Scaling to use for the contour color axis from the theoretical maximum charge at every single plot step. Default is 10, meaning that the maximum of the color scale axis is equal to the total amount of charges divided by ten (values above this are displayed in the same maximum color). Parameter can be used to improve the color scale of the contour plots.
 * `output_animations_color_markers`: Determines if colors should be for the markers in the animations, defaults to false.
+* `output_max_gain_histo`: Determines maximum gain value to be plotted in the gain histograms. Defaults to 25.
 
 ## Usage
 

--- a/src/modules/TransientPropagation/README.md
+++ b/src/modules/TransientPropagation/README.md
@@ -86,6 +86,7 @@ It should be noted that generating the animations is time-consuming and should b
 * `output_animations_marker_size` : Scaling for the markers on the animation, defaults to one. The markers are already internally scaled to the charge of their step, normalized to the maximum charge.
 * `output_animations_contour_max_scaling` : Scaling to use for the contour color axis from the theoretical maximum charge at every single plot step. Default is 10, meaning that the maximum of the color scale axis is equal to the total amount of charges divided by ten (values above this are displayed in the same maximum color). Parameter can be used to improve the color scale of the contour plots.
 * `output_animations_color_markers`: Determines if colors should be for the markers in the animations, defaults to false.
+* `output_max_gain_histo`: Determines maximum value to be plotted in the gain histograms. Defaults to 25.
 
 ## Usage
 

--- a/src/modules/TransientPropagation/TransientPropagationModule.cpp
+++ b/src/modules/TransientPropagation/TransientPropagationModule.cpp
@@ -72,6 +72,7 @@ TransientPropagationModule::TransientPropagationModule(Configuration& config,
     config_.setDefault<bool>("output_plots_align_pixels", false);
     config_.setDefault<double>("output_plots_theta", 0.0f);
     config_.setDefault<double>("output_plots_phi", 0.0f);
+    config_.setDefault<int>("output_max_gain_histo",25);
 
     // Copy some variables from configuration to avoid lookups:
     temperature_ = config_.get<double>("temperature");
@@ -91,6 +92,12 @@ TransientPropagationModule::TransientPropagationModule(Configuration& config,
     output_linegraphs_recombined_ = config_.get<bool>("output_linegraphs_recombined");
     output_linegraphs_trapped_ = config_.get<bool>("output_linegraphs_trapped");
     output_plots_step_ = config_.get<double>("output_plots_step");
+    output_max_gain_histo_=config.get<int>("output_max_gain_histo");
+
+    // Avoids wrong gain histogram inputs
+    if(output_max_gain_histo_ <2) {
+        throw std::runtime_error("Config error: 'output_max_gain_histo' must be >=2.");
+    }
 
     // Enable multithreading of this module if multithreading is enabled and no per-event output plots are requested:
     // FIXME: Review if this is really the case or we can still use multithreading
@@ -322,27 +329,27 @@ void TransientPropagationModule::initialize() {
             gain_primary_histo_ = CreateHistogram<TH1D>(
                 "gain_primary_histo",
                 "Gain per primarily induced charge carrier group after propagation;gain;number of groups transported",
-                24,
+                output_max_gain_histo_ - 1,
                 1,
-                25);
+                output_max_gain_histo_);
             gain_all_histo_ =
                 CreateHistogram<TH1D>("gain_all_histo",
                                       "Gain per charge carrier group after propagation;gain;number of groups transported",
-                                      24,
+                                      output_max_gain_histo_ - 1,
                                       1,
-                                      25);
+                                      output_max_gain_histo_);
             gain_e_histo_ =
                 CreateHistogram<TH1D>("gain_e_histo",
                                       "Gain per primary electron group after propagation;gain;number of groups transported",
-                                      24,
+                                      output_max_gain_histo_ - 1,
                                       1,
-                                      25);
+                                      output_max_gain_histo_);
             gain_h_histo_ =
                 CreateHistogram<TH1D>("gain_h_histo",
                                       "Gain per primary hole group after propagation;gain;number of groups transported",
-                                      24,
+                                      output_max_gain_histo_ - 1,
                                       1,
-                                      25);
+                                      output_max_gain_histo_);
             multiplication_level_histo_ = CreateHistogram<TH1D>(
                 "multiplication_level_histo",
                 "Multiplication level of propagated charge carriers;multiplication level;charge carriers",

--- a/src/modules/TransientPropagation/TransientPropagationModule.hpp
+++ b/src/modules/TransientPropagation/TransientPropagationModule.hpp
@@ -113,6 +113,7 @@ namespace allpix {
         unsigned int max_charge_groups_{};
 
         unsigned int max_multiplication_level_{};
+        int output_max_gain_histo_{};
 
         // Models for electron and hole mobility and lifetime
         Mobility mobility_;


### PR DESCRIPTION
This PR contains modifications to the source code, allowing user-defined inputs for the maximum value of the gain histograms. This is done via the `output_max_gain_histo` variable, which can be defined in both `[GenericPropagation]` and `[TransientPropagation]` modules. The default value for this variable is 25, for compatibility with the previous hard-coded version. The README files were also modified to encompass the description of this variables.