### PR TITLE
Transient propagation has inaccurate local_gain for first pass through the while loop

### DIFF
--- a/src/modules/GenericPropagation/GenericPropagationModule.cpp
+++ b/src/modules/GenericPropagation/GenericPropagationModule.cpp
@@ -548,6 +548,8 @@ GenericPropagationModule::propagate(Event* event,
     // Continue propagation until the deposit is outside the sensor
     Eigen::Vector3d last_position = position;
     ROOT::Math::XYZVector efield{}, last_efield{};
+    // Initialize last_efield for first pass through the while loop
+    last_efield = detector_->getElectricField(static_cast<ROOT::Math::XYZPoint>(last_position));
     double last_time = 0;
     size_t next_idx = 0;
     auto state = CarrierState::MOTION;
@@ -564,7 +566,6 @@ GenericPropagationModule::propagate(Event* event,
         // Save previous position and time
         last_position = position;
         last_time = runge_kutta.getTime();
-        last_efield = efield;
 
         // Get electric field at current (pre-step) position
         efield = detector_->getElectricField(static_cast<ROOT::Math::XYZPoint>(position));
@@ -728,6 +729,9 @@ GenericPropagationModule::propagate(Event* event,
         runge_kutta.setTimeStep(timestep);
 
         charge += n_secondaries;
+
+        // Save previous electric field
+        last_efield = efield;
     }
 
     // Find proper final position in the sensor

--- a/src/modules/GenericPropagation/GenericPropagationModule.cpp
+++ b/src/modules/GenericPropagation/GenericPropagationModule.cpp
@@ -451,7 +451,7 @@ void GenericPropagationModule::run(Event* event) {
 
 /**
  * Propagation is simulated using a parameterization for the electron mobility. This is used to calculate the electron
- * velocity at every point with help of the electric field map of the detector. An Runge-Kutta integration is applied in
+ * velocity at every point with help of the electric field map of the detector. A Runge-Kutta integration is applied in
  * multiple steps, adding a random diffusion to the propagating charge every step.
  */
 std::tuple<unsigned int, unsigned int, unsigned int, unsigned int, long double>
@@ -472,7 +472,7 @@ GenericPropagationModule::propagate(Event* event,
         return {};
     }
 
-    // Create a runge kutta solver using the electric field as step function
+    // Create a Runge-Kutta solver using the electric field as step function
     Eigen::Vector3d position(pos.x(), pos.y(), pos.z());
 
     unsigned int propagated_charges_count = 0;
@@ -522,7 +522,6 @@ GenericPropagationModule::propagate(Event* event,
         auto raw_field = detector_->getElectricField(static_cast<ROOT::Math::XYZPoint>(cur_pos));
         Eigen::Vector3d efield(raw_field.x(), raw_field.y(), raw_field.z());
 
-        Eigen::Vector3d velocity;
         auto magnetic_field = detector_->getMagneticField(static_cast<ROOT::Math::XYZPoint>(cur_pos));
         Eigen::Vector3d bfield(magnetic_field.x(), magnetic_field.y(), magnetic_field.z());
 
@@ -541,7 +540,7 @@ GenericPropagationModule::propagate(Event* event,
         return static_cast<int>(type) * mob * (efield + term1 + term2) / rnorm;
     };
 
-    // Create the runge kutta solver with an RKF5 tableau, using different velocity calculators depending on the magnetic
+    // Create the Runge-Kutta solver with an RKF5 tableau, using different velocity calculators depending on the magnetic
     // field
     auto runge_kutta = make_runge_kutta(
         tableau::RK5, (has_magnetic_field_ ? carrier_velocity_withB : carrier_velocity_noB), timestep_start_, position);
@@ -571,7 +570,7 @@ GenericPropagationModule::propagate(Event* event,
         efield = detector_->getElectricField(static_cast<ROOT::Math::XYZPoint>(position));
         auto doping = detector_->getDopingConcentration(static_cast<ROOT::Math::XYZPoint>(position));
 
-        // Execute a Runge Kutta step
+        // Execute a Runge-Kutta step
         auto step = runge_kutta.step();
 
         // Get the current result and timestep

--- a/src/modules/TransientPropagation/TransientPropagationModule.cpp
+++ b/src/modules/TransientPropagation/TransientPropagationModule.cpp
@@ -591,6 +591,8 @@ TransientPropagationModule::propagate(Event* event,
     // Continue propagation until the deposit is outside the sensor
     Eigen::Vector3d last_position = position;
     ROOT::Math::XYZVector efield{}, last_efield{};
+    // Initialize last_efield for first pass through the while loop
+    last_efield = detector_->getElectricField(static_cast<ROOT::Math::XYZPoint>(last_position));
     size_t next_idx = 0;
     auto state = CarrierState::MOTION;
     while(state == CarrierState::MOTION && (initial_time_local + runge_kutta.getTime()) < integration_time_) {
@@ -602,10 +604,6 @@ TransientPropagationModule::propagate(Event* event,
                 next_idx = output_plot_points.at(output_plot_index).second.size();
             }
         }
-
-        // Save previous position and time
-        last_position = position;
-        last_efield = efield;
 
         // Get electric field at current (pre-step) position
         efield = detector_->getElectricField(static_cast<ROOT::Math::XYZPoint>(position));
@@ -849,6 +847,10 @@ TransientPropagationModule::propagate(Event* event,
         }
         // Increase charge at the end of the step in case of impact ionization
         charge += n_secondaries;
+
+        // Save previous position and time
+        last_position = position;
+        last_efield = efield;
     }
 
     if(output_plots_ && !multiplication_.is<NoImpactIonization>()) {

--- a/src/modules/TransientPropagation/TransientPropagationModule.cpp
+++ b/src/modules/TransientPropagation/TransientPropagationModule.cpp
@@ -585,7 +585,7 @@ TransientPropagationModule::propagate(Event* event,
         return static_cast<int>(type) * mob * (efield + term1 + term2) / rnorm;
     };
 
-    // Create the runge kutta solver with an RK4 tableau, no error estimation required since we're not adapting step size
+    // Create the Runge-Kutta solver with an RK4 tableau, no error estimation required since we're not adapting step size
     auto runge_kutta = make_runge_kutta(
         tableau::RK4, (has_magnetic_field_ ? carrier_velocity_withB : carrier_velocity_noB), timestep_, position);
 
@@ -612,7 +612,7 @@ TransientPropagationModule::propagate(Event* event,
         efield = detector_->getElectricField(static_cast<ROOT::Math::XYZPoint>(position));
         auto doping = detector_->getDopingConcentration(static_cast<ROOT::Math::XYZPoint>(position));
 
-        // Execute a Runge Kutta step
+        // Execute a Runge-Kutta step
         auto step = runge_kutta.step();
 
         // Get the current result

--- a/src/modules/TransientPropagation/TransientPropagationModule.cpp
+++ b/src/modules/TransientPropagation/TransientPropagationModule.cpp
@@ -848,7 +848,7 @@ TransientPropagationModule::propagate(Event* event,
         // Increase charge at the end of the step in case of impact ionization
         charge += n_secondaries;
 
-        // Save previous position and time
+        // Save previous position and electric field
         last_position = position;
         last_efield = efield;
     }

--- a/src/modules/TransientPropagation/TransientPropagationModule.cpp
+++ b/src/modules/TransientPropagation/TransientPropagationModule.cpp
@@ -566,7 +566,6 @@ TransientPropagationModule::propagate(Event* event,
         auto raw_field = detector_->getElectricField(static_cast<ROOT::Math::XYZPoint>(cur_pos));
         Eigen::Vector3d efield(raw_field.x(), raw_field.y(), raw_field.z());
 
-        Eigen::Vector3d velocity;
         auto magnetic_field = detector_->getMagneticField(static_cast<ROOT::Math::XYZPoint>(cur_pos));
         Eigen::Vector3d bfield(magnetic_field.x(), magnetic_field.y(), magnetic_field.z());
 

--- a/src/modules/TransientPropagation/TransientPropagationModule.cpp
+++ b/src/modules/TransientPropagation/TransientPropagationModule.cpp
@@ -796,11 +796,6 @@ TransientPropagationModule::propagate(Event* event,
             // Induced charge on electrode is q_int = q * (phi(x1) - phi(x0))
             auto induced = charge * (ramo - last_ramo) * static_cast<std::underlying_type<CarrierType>::type>(type);
 
-            auto induced_primary = level != 0 ? 0.
-                                              : initial_charge * (ramo - last_ramo) *
-                                                    static_cast<std::underlying_type<CarrierType>::type>(type);
-            auto induced_secondary = induced - induced_primary;
-
             LOG(TRACE) << "Pixel " << pixel_index << " dPhi = " << (ramo - last_ramo) << ", induced " << type
                        << " q = " << Units::display(induced, "e");
 
@@ -834,6 +829,10 @@ TransientPropagationModule::propagate(Event* event,
                     induced_charge_h_map_->Fill(inPixel_um_x, inPixel_um_y, induced);
                 }
                 if(!multiplication_.is<NoImpactIonization>()) {
+                    auto induced_primary = level != 0 ? 0.
+                                                      : initial_charge * (ramo - last_ramo) *
+                                                            static_cast<std::underlying_type<CarrierType>::type>(type);
+                    auto induced_secondary = induced - induced_primary;
                     induced_charge_primary_histo_->Fill(initial_time_local + runge_kutta.getTime(), induced_primary);
                     induced_charge_secondary_histo_->Fill(initial_time_local + runge_kutta.getTime(), induced_secondary);
                     if(type == CarrierType::ELECTRON) {

--- a/src/modules/TransientPropagation/tests/15-impact-secondary.conf
+++ b/src/modules/TransientPropagation/tests/15-impact-secondary.conf
@@ -31,4 +31,4 @@ timestep = 1ps
 multiplication_model = "okuto"
 multiplication_threshold = 100kV/cm
 
-#PASS Set of 1 charge carriers ("h") generated from impact ionization on (444.972um,219.825um,77.55um)
+#PASS Set of 1 charge carriers ("h") generated from impact ionization on (445.128um,219.682um,77.565um)


### PR DESCRIPTION
This patch is for the propagate() function in TransientPropagation.cpp

The first time through the while loop, efield hasn't been set before the assignment of efield to last_efield. (See TransientPropagation.cpp, line 609 in the master branch.) This gives last_efield a value of zeroes the first time through the loop, so last_efield.Mag2() == 0. Hence, the calculation of local_gain is inaccurate. For example, when running the 13-impact-ionization.conf test configuration, the first iteration has local_gain = 1 and the next 20 or so iterations have local_gain = 1.00028.

This patch initializes last_efield before the while loop so that it has the same value as efield (when it's set for the first time in the while loop). Just like last_position is initialized before the while loop to have the same value as position the first time through the while loop.

Note 1: Of course, if this is the intended behavior, I'll delete the PR.
Note 2: There are a few other minor changes to the code. I think the commits explain them, but can clarify if need be. The above is the only functional change.
Note 3: If this patch is useful, I can extend this PR to incorporate the same changes into GenericPropagation.cpp (if desired).